### PR TITLE
Access metadata easily via properties.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ unreleased
   to the full dimension key including the category set like ``area (ISO3)``. Works with
   ``ds.pr[key]`` and ``ds.pr.loc[selection]`` as well as ``da.pr.loc[selection]``.
 * Add usage documentation for all currently included functionality.
+* Access metadata easily via properties like ``ds.pr.references``.
 
 0.2.0
 -----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,6 +59,14 @@ Attributes
    :template: autosummary/accessor_attribute.rst
 
     Dataset.pr.loc
+    Dataset.pr.references
+    Dataset.pr.rights
+    Dataset.pr.contact
+    Dataset.pr.title
+    Dataset.pr.comment
+    Dataset.pr.institution
+    Dataset.pr.history
+    Dataset.pr.source
 
 .. _dsmeth:
 

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -71,7 +71,54 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Selecting Data\n",
+    "## Accessing metadata\n",
+    "\n",
+    "Metadata is stored in the `attrs` of Datasets, and you can of course\n",
+    "access it directly there.\n",
+    "Additionally, you can access the PRIMAP2 metadata directly under\n",
+    "the `.pr` namespace, which has the advantage that autocompletion\n",
+    "works in ipython and IDEs and typos will be caught immediately."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "ds.pr.title"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "ds.pr.title = \"Another title\"\n",
+    "ds.pr.title"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Selecting data\n",
     "\n",
     "Of course, data can be selected using the\n",
     "[xarray indexing methods](https://xarray.pydata.org/en/stable/indexing.html),\n",

--- a/primap2/_metadata.py
+++ b/primap2/_metadata.py
@@ -1,0 +1,83 @@
+from . import _accessor_base
+
+
+class DatasetMetadataAccessor(_accessor_base.BaseDatasetAccessor):
+    @property
+    def references(self) -> str:
+        """citable reference(s) describing the data
+
+        If the references start with ``doi:``, it is a doi, otherwise it is a
+        free-form literature reference.
+        """
+        return self._ds.attrs["references"]
+
+    @references.setter
+    def references(self, value: str):
+        self._ds.attrs["references"] = value
+
+    @property
+    def rights(self) -> str:
+        """license or other usage restrictions of the data"""
+        return self._ds.attrs["rights"]
+
+    @rights.setter
+    def rights(self, value: str):
+        self._ds.attrs["rights"] = value
+
+    @property
+    def contact(self) -> str:
+        """who can answer questions about the data"""
+        return self._ds.attrs["contact"]
+
+    @contact.setter
+    def contact(self, value: str):
+        self._ds.attrs["contact"] = value
+
+    @property
+    def title(self) -> str:
+        """a succinct description"""
+        return self._ds.attrs["title"]
+
+    @title.setter
+    def title(self, value: str):
+        self._ds.attrs["title"] = value
+
+    @property
+    def comment(self) -> str:
+        """longer form description"""
+        return self._ds.attrs["comment"]
+
+    @comment.setter
+    def comment(self, value: str):
+        self._ds.attrs["comment"] = value
+
+    @property
+    def institution(self) -> str:
+        """where the data originates"""
+        return self._ds.attrs["institution"]
+
+    @institution.setter
+    def institution(self, value: str):
+        self._ds.attrs["institution"] = value
+
+    @property
+    def history(self) -> str:
+        """processing steps done on the data
+
+        In this property, an audit trail of modifications can be stored.
+        Steps are separated by a newline character, and processing steps should append
+        to the field."""
+        return self._ds.attrs["history"]
+
+    @history.setter
+    def history(self, value: str):
+        self._ds.attrs["history"] = value
+
+    @property
+    def source(self) -> str:
+        """a short identifier for the source of the data"""
+        return self._ds["source"].item()
+
+    @source.setter
+    def source(self, value: str):
+        self._ds["source"] = [value]

--- a/primap2/accessors.py
+++ b/primap2/accessors.py
@@ -9,6 +9,7 @@ from ._alias_selection import (
 )
 from ._data_format import DatasetDataFormatAccessor
 from ._downscale import DataArrayDownscalingAccessor, DatasetDownscalingAccessor
+from ._metadata import DatasetMetadataAccessor
 from ._units import DataArrayUnitAccessor, DatasetUnitAccessor
 
 
@@ -18,6 +19,7 @@ class PRIMAP2DatasetAccessor(
     DatasetAliasSelectionAccessor,
     DatasetDataFormatAccessor,
     DatasetDownscalingAccessor,
+    DatasetMetadataAccessor,
     DatasetUnitAccessor,
 ):
     """Collection of methods useful for climate policy analysis."""

--- a/primap2/tests/conftest.py
+++ b/primap2/tests/conftest.py
@@ -87,9 +87,8 @@ def opulent_ds():
             "title": "Completely invented GHG inventory data",
             "comment": "GHG inventory data ...",
             "institution": "PIK",
-            "history": """2021-01-14 14:50 data invented
-                2021-01-14 14:51 additional processing step
-                """,
+            "history": "2021-01-14 14:50 data invented\n"
+            "2021-01-14 14:51 additional processing step",
         },
     )
 

--- a/primap2/tests/test_metadata.py
+++ b/primap2/tests/test_metadata.py
@@ -1,0 +1,32 @@
+"""Tests for _metadata.py"""
+
+
+def test_metadata_properties(opulent_ds):
+    ds = opulent_ds
+    assert ds.pr.references == "doi:10.1012"
+    assert ds.pr.rights == "Use however you want."
+    assert ds.pr.contact == "lol_no_one_will_answer@example.com"
+    assert ds.pr.title == "Completely invented GHG inventory data"
+    assert ds.pr.comment == "GHG inventory data ..."
+    assert ds.pr.institution == "PIK"
+    assert ds.pr.history == (
+        "2021-01-14 14:50 data invented\n" "2021-01-14 14:51 additional processing step"
+    )
+    assert ds.pr.source == "RAND2020"
+
+    ds.pr.references = "references"
+    assert ds.pr.references == "references"
+    ds.pr.rights = "rights"
+    assert ds.pr.rights == "rights"
+    ds.pr.contact = "contact"
+    assert ds.pr.contact == "contact"
+    ds.pr.title = "title"
+    assert ds.pr.title == "title"
+    ds.pr.comment = "comment"
+    assert ds.pr.comment == "comment"
+    ds.pr.institution = "institution"
+    assert ds.pr.institution == "institution"
+    ds.pr.history = "history"
+    assert ds.pr.history == "history"
+    ds.pr.source = "source"
+    assert ds.pr.source == "source"


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in ``CHANGELOG.rst`` added

## Description

Access metadata easily via properties like `ds.pr.references`. This helps because properties are typed and guard against
typos. Also, they are documented using docstrings and therefore available in on-line help.
