### PR TITLE
Unpin h5py and require fixed h5netcdf version.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,8 +17,8 @@ ipykernel
 jupyter
 loguru
 scipy
-h5netcdf
-h5py<3
+h5netcdf>=0.10
+h5py
 git+https://github.com/keewis/sphinx-autosummary-accessors
 numpydoc
 xarray

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ requirements = [
     "openscm_units",
     "loguru",
     "scipy",
-    "h5netcdf",
-    "h5py<3",
+    "h5netcdf>=0.10",
+    "h5py",
     "bottleneck",
     "matplotlib",
 ]


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Description in ``CHANGELOG.rst`` added

## Description

h5py was pinned due to API changes in Version 3, but this was fixed in xarray at https://github.com/pydata/xarray/pull/4893 , so we can now unpin h5py but have to use a newer h5netcdf.
