### PR TITLE
add functionality to convert long format dataframe (with non-PRIMAP) …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 
 Unreleased
 ----------
-
+* Add function to convert long format dataframe to interchange format
+* Add functions to help reading of different national GHG inventories
 
 0.5.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ----------
+* Split wide csv reading function into a conversion function and a wrapper
 * Add function to convert long format dataframe to interchange format
 * Add functions to help reading of different national GHG inventories
 

--- a/changelog_unreleased/read_nir_files.rst
+++ b/changelog_unreleased/read_nir_files.rst
@@ -1,3 +1,6 @@
 * Split wide csv reading function into a conversion function and a wrapper
 * Add function to convert long format dataframe to interchange format
 * Add functions to help reading of different national GHG inventories
+* Add functionality to fill columns using information from other
+  columns to csv reading and dataframe conversion functions
+* Add additional coordinates to interchange format and data reading functions

--- a/changelog_unreleased/read_nir_files.rst
+++ b/changelog_unreleased/read_nir_files.rst
@@ -1,0 +1,3 @@
+* Split wide csv reading function into a conversion function and a wrapper
+* Add function to convert long format dataframe to interchange format
+* Add functions to help reading of different national GHG inventories

--- a/primap2/pm2io/_GHG_inventory_reading.py
+++ b/primap2/pm2io/_GHG_inventory_reading.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
@@ -38,7 +38,7 @@ def nir_add_unit_information(
         A dict with the fields
         * regexp_entity: regular expression that extracts the entity from the cell value
         * regexp_unit: regular expression that extracts the unit from the cell value
-        * manual_repl: optional: dict defining unit an d entity for given cell values
+        * manual_repl: optional: dict defining unit and entity for given cell values
         * default_unit: unit to be used if no unit can be extracted an no unit is given
 
     Returns
@@ -89,7 +89,9 @@ def nir_add_unit_information(
     return df_nir
 
 
-def nir_convert_df_to_long(df_nir: pd.DataFrame, year: int) -> pd.DataFrame:
+def nir_convert_df_to_long(
+    df_nir: pd.DataFrame, year: int, header_long: Optional[List[str]] = None
+) -> pd.DataFrame:
     """
     This function converts an entity-wide NIR table for a single year to a long format
     DataFrame. The input DataFrame is required to have the following structure:
@@ -104,12 +106,16 @@ def nir_convert_df_to_long(df_nir: pd.DataFrame, year: int) -> pd.DataFrame:
         Pandas DataFrame with the NIR table to be converted
     year: int
         Year of the given data
+    header_long: list, optional
+        specify a non-standard column header, e.g. with only category code
+        or orig_cat_name
 
     Returns
     -------
 
     """
-    header_long = ["category", "orig_cat_name", "entity", "unit", "time", "data"]
+    if header_long is None:
+        header_long = ["category", "orig_cat_name", "entity", "unit", "time", "data"]
 
     df_stacked = df_nir.stack([0, 1]).to_frame()
     df_stacked.insert(0, "year", str(year))

--- a/primap2/pm2io/_GHG_inventory_reading.py
+++ b/primap2/pm2io/_GHG_inventory_reading.py
@@ -1,0 +1,118 @@
+import re
+from typing import Any, Dict, Union
+
+import pandas as pd
+
+# this file contains functions for reading of country GHG inventories
+# from National Inventory Reports (NIR), biannual Update Reports (BUR),
+# and other official country emissions inventories
+# Most of the functions in this file are exposed to the outside yet they
+# currently do not undergo the strict testing applied to the rest of PRIMAP2 as
+# they are added during the process of reading an preparing data for the PRIMAP-hist
+# update. Testing will be added in the future.
+
+
+def nir_add_unit_information(
+    df_nir: pd.DataFrame, *, unit_row: Union[str, int], unit_info: Dict[str, Any]
+) -> pd.DataFrame:
+    """
+    This functions adds unit information to the header of a "entity-wide" file as
+    present in the standard table format of National Inventory Reports (NIRs). The
+    unit and entity information is extracted from combined unit and entity information
+    in the row defined by `unit_row`. The parameter `unit_info` determines how this is
+    done by regular expressions for unit and entity and a dict for manual replacements.
+    For each column the routine tries to extract a unit using the regular expression.
+    If this fails it looks in the `unit_info.manual_repl` dict for unit and entity
+    information. If there is no information the default unit given in
+    `unit_info.default_unit` is used. In this case the analyzed value is used as entity
+    unchanged.
+
+    Parameters
+    ----------
+    df_nir : pd.DataFrame
+        Pandas DataFrame with the table to process
+    unit_row : str or int
+        String "header" to indicate that the column header should be used to derive the
+        unit information or an integer specifying the row to use for unit information.
+    unit_info : dict
+        A dict with the fields
+        * regexp_entity: regular expression that extracts the entity from the cell value
+        * regexp_unit: regular expression that extracts the unit from the cell value
+        * manual_repl: optional: dict defining unit an d entity for given cell values
+        * default_unit: unit to be used if no unit can be extracted an no unit is given
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with explicit unit information (as column header)
+    """
+
+    if "manual_repl" not in unit_info:
+        unit_info["manual_repl"] = {}
+
+    # get the data to extract the units and entities from
+    # can be either the header row or a regular row
+    if unit_row == "header":
+        values_for_units = list(df_nir.columns)
+    else:
+        # unit_row must be an integer
+        values_for_units = list(df_nir.iloc[unit_row])
+
+    re_unit = re.compile(unit_info["regexp_unit"])
+    re_entity = re.compile(unit_info["regexp_entity"])
+
+    units = values_for_units.copy()
+    entities = values_for_units.copy()
+
+    for idx, value in enumerate(values_for_units):
+        if value in unit_info["manual_repl"]:
+            units[idx] = unit_info["manual_repl"][value][1]
+            entities[idx] = unit_info["manual_repl"][value][0]
+        else:
+            unit = re_unit.findall(value)
+            if unit:
+                units[idx] = unit[0]
+            else:
+                units[idx] = unit_info["default_unit"]
+            entity = re_entity.findall(value)
+            if entity:
+                entities[idx] = entity[0]
+            else:
+                entities[idx] = value
+
+    new_header = [entities, units]
+
+    df_nir.columns = new_header
+    if unit_row != "header":
+        df_nir.drop(unit_row)
+
+    return df_nir
+
+
+def nir_convert_df_to_long(df_nir: pd.DataFrame, year: int) -> pd.DataFrame:
+    """
+    This function converts an entity-wide NIR table for a single year to a long format
+    DataFrame. The input DataFrame is required to have the following structure:
+    * Columns for category, original category name, and data in this order, where
+    category and original category name form a multiindex.
+    * Column header as multiindex for entity and unit
+    A column for the year is added during the conversion.
+
+    Parameters
+    ----------
+    df_nir: pd.DataFrame
+        Pandas DataFrame with the NIR table to be converted
+    year: int
+        Year of the given data
+
+    Returns
+    -------
+
+    """
+    header_long = ["category", "orig_cat_name", "entity", "unit", "time", "data"]
+
+    df_stacked = df_nir.stack([0, 1]).to_frame()
+    df_stacked.insert(0, "year", str(year))
+    df_stacked.reset_index(inplace=True)
+    df_stacked.columns = header_long
+    return df_stacked

--- a/primap2/pm2io/__init__.py
+++ b/primap2/pm2io/__init__.py
@@ -1,7 +1,11 @@
 """Data reading module of the PRIMAP2 climate policy analysis package."""
 
 
-from ._data_reading import read_long_csv_file_if, read_wide_csv_file_if
+from ._data_reading import (
+    convert_long_dataframe_if,
+    read_long_csv_file_if,
+    read_wide_csv_file_if,
+)
 from ._interchange_format import (
     from_interchange_format,
     read_interchange_format,
@@ -11,6 +15,7 @@ from ._interchange_format import (
 __all__ = [
     "read_long_csv_file_if",
     "read_wide_csv_file_if",
+    "convert_long_dataframe_if",
     "from_interchange_format",
     "read_interchange_format",
     "write_interchange_format",

--- a/primap2/pm2io/__init__.py
+++ b/primap2/pm2io/__init__.py
@@ -6,6 +6,7 @@ from ._data_reading import (
     read_long_csv_file_if,
     read_wide_csv_file_if,
 )
+from ._GHG_inventory_reading import nir_add_unit_information, nir_convert_df_to_long
 from ._interchange_format import (
     from_interchange_format,
     read_interchange_format,
@@ -19,4 +20,6 @@ __all__ = [
     "from_interchange_format",
     "read_interchange_format",
     "write_interchange_format",
+    "nir_convert_df_to_long",
+    "nir_add_unit_information",
 ]

--- a/primap2/pm2io/__init__.py
+++ b/primap2/pm2io/__init__.py
@@ -3,6 +3,7 @@
 
 from ._data_reading import (
     convert_long_dataframe_if,
+    convert_wide_dataframe_if,
     read_long_csv_file_if,
     read_wide_csv_file_if,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "read_long_csv_file_if",
     "read_wide_csv_file_if",
     "convert_long_dataframe_if",
+    "convert_wide_dataframe_if",
     "from_interchange_format",
     "read_interchange_format",
     "write_interchange_format",

--- a/primap2/pm2io/_conversion.py
+++ b/primap2/pm2io/_conversion.py
@@ -35,6 +35,7 @@ def convert_unit_primap_to_primap2(unit: str, entity: str) -> str:
     # define exceptions
     exception_units = {
         "CO2eq": "CO2",  # convert to just CO2
+        "CO₂eq": "CO2",  # convert to just CO2 (not for PRIMAP but e.g. NIRs)
         "<entity>N": "N",
         "C": "C",  # don't add variable here
     }
@@ -57,6 +58,9 @@ def convert_unit_primap_to_primap2(unit: str, entity: str) -> str:
     for this_unit in units_prefixes:
         regexp_str = regexp_str + this_unit + "|"
     regexp_str = regexp_str[0:-1] + ")"
+
+    # remove spaces for more flexibility in input units
+    unit = unit.replace(" ", "")
 
     # add entity and time frame to unit
     # special units will be replaced later

--- a/primap2/pm2io/_data_reading.py
+++ b/primap2/pm2io/_data_reading.py
@@ -933,7 +933,7 @@ def read_wide_csv(
     # remove all cols not in the specification
     columns = data.columns.values
     if add_coords_cols:
-        add_coords_col_names = set([value[0] for value in add_coords_cols.values()])
+        add_coords_col_names = {value[0] for value in add_coords_cols.values()}
     else:
         add_coords_col_names = set()
 
@@ -977,7 +977,7 @@ def read_long_csv(
         parse_dates = False
 
     if add_coords_cols:
-        add_coords_col_names = set([value[0] for value in add_coords_cols.values()])
+        add_coords_col_names = {value[0] for value in add_coords_cols.values()}
     else:
         add_coords_col_names = set()
 

--- a/primap2/pm2io/_data_reading.py
+++ b/primap2/pm2io/_data_reading.py
@@ -453,7 +453,7 @@ def convert_wide_dataframe_if(
         `data format documentation <https://primap2.readthedocs.io/en/stable/data_format_details.html#dataset-attributes>`_.  # noqa: E501
 
     time_format : str
-        either str with strftime style format used to parse the time information for
+        str with strftime style format used to parse the time information for
         the data columns.
         Default: "%Y", which will match years.
 

--- a/primap2/pm2io/_data_reading.py
+++ b/primap2/pm2io/_data_reading.py
@@ -100,6 +100,10 @@ def convert_long_dataframe_if(
         values will be filled (or replaced). Vales are dicts with primap2 dimension names
         as keys. These are the source columns. The values are dicts with source value -
         target value mappings.
+        The value filling can do everything that the value mapping can, but while mapping
+        can only replace values within a column using information from that column, the
+        filing function can also fill or replace data based on values from a different
+        column.
         This can be used to e.g. fill missing category codes based on category names or
         to replace category codes which do not meet the terminology using the category
         names.
@@ -745,8 +749,6 @@ def fill_from_other_col(
     -------
     pd.DataFrame
     """
-    df_filled = df.copy()
-
     dim_aliases = _alias_selection.translations_from_attrs(attrs, include_entity=True)
 
     # loop over target columns in value mapping
@@ -759,14 +761,10 @@ def fill_from_other_col(
             target_col_name = dim_aliases.get(target_col, target_col)
             source_col_name = dim_aliases.get(source_col, source_col)
             for source_value in mapping_info:
-                df_filled.loc[
-                    df_filled[source_col_name] == source_value, target_col_name
-                ] = df_filled.loc[
-                    df_filled[source_col_name] == source_value, target_col_name
-                ] = mapping_info[
-                    source_value
-                ]
-    return df_filled
+                df.loc[df[source_col_name] == source_value, target_col_name] = df.loc[
+                    df[source_col_name] == source_value, target_col_name
+                ] = mapping_info[source_value]
+    return df
 
 
 def add_dimensions_from_defaults(

--- a/primap2/pm2io/_data_reading.py
+++ b/primap2/pm2io/_data_reading.py
@@ -41,6 +41,178 @@ NA_VALUES = [
 ]
 
 
+def convert_long_dataframe_if(
+    data_long: pd.DataFrame,
+    *,
+    coords_cols: Dict[str, str],
+    coords_defaults: Optional[Dict[str, Any]] = None,
+    coords_terminologies: Dict[str, str],
+    coords_value_mapping: Optional[Dict[str, Any]] = None,
+    coords_value_filling: Optional[Dict[str, Dict[str, Dict]]] = None,
+    filter_keep: Optional[Dict[str, Dict[str, Any]]] = None,
+    filter_remove: Optional[Dict[str, Dict[str, Any]]] = None,
+    meta_data: Optional[Dict[str, Any]] = None,
+    time_format: str = "%Y-%m-%d",
+) -> pd.DataFrame:
+    """convert a DataFrame in long (tidy) format into the PRIMAP2 interchange format.
+
+    Columns can be renamed or filled with default values to match the PRIMAP2 structure.
+    Where we refer to "dimensions" in the parameter description below we mean the basic
+    dimension names without the added terminology (e.g. "area" not "area (ISO3)"). The
+    terminology information will be added by this function. You can not use the short
+    dimension names in the attributes (e.g. "cat" instead of "category").
+
+    Parameters
+    ----------
+    data_long: str, pd.DataFrame
+        Long format DataFrame file which will be converted.
+
+    coords_cols : dict
+        Dict where the keys are column names in the files to be read and the value is
+        the dimension in PRIMAP2. To specify the data column containing the observable,
+        use the "data" key. For secondary categories use a ``sec_cats__`` prefix.
+
+    coords_defaults : dict, optional
+        Dict for default values of coordinates / dimensions not given in the csv files.
+        The keys are the dimension names and the values are the values for
+        the dimensions. For secondary categories use a ``sec_cats__`` prefix.
+
+    coords_terminologies : dict
+        Dict defining the terminologies used for the different coordinates (e.g. ISO3
+        for area). Only possible coordinates here are: area, category, scenario,
+        entity, and secondary categories. For secondary categories use a ``sec_cats__``
+        prefix. All entries different from "area", "category", "scenario", "entity", and
+        ``sec_cats__<name>`` will raise a ValueError.
+
+    coords_value_mapping : dict, optional
+        A dict with primap2 dimension names as keys. Values are dicts with input values
+        as keys and output values as values. A standard use case is to map gas names
+        from input data to the standardized names used in primap2.
+        Alternatively a value can also be a function which transforms one CSV metadata
+        value into the new metadata value.
+        A third possibility is to give a string as a value, which defines a rule for
+        translating metadata values. For the "category", "entity", and "unit" columns,
+        the rule "PRIMAP1" is available, which translates from PRIMAP1 metadata to
+        PRIMAP2 metadata.
+
+    coords_value_filling : dict, optional
+        A dict with primap2 dimension names as keys. These are the target columns where
+        values will be filled (or replaced). Vales are dicts with primap2 dimension names
+        as keys. These are the source columns. The values are dicts with source value -
+        target value mappings.
+        This can be used to e.g. fill missing category codes based on category names or
+        to replace category codes which do not meet the terminology using the category
+        names.
+
+    filter_keep : dict, optional
+        Dict defining filters of data to keep. Filtering is done before metadata
+        mapping, so use original metadata values to define the filter. Column names are
+        as in the csv file. Each entry in the dict defines an individual filter.
+        The names of the filters have no relevance. Default: keep all data.
+
+    filter_remove : dict, optional
+        Dict defining filters of data to remove. Filtering is done before metadata
+        mapping, so use original metadata values to define the filter. Column names are
+        as in the csv file. Each entry in the dict defines an individual filter.
+        The names of the filters have no relevance.
+
+    meta_data : dict, optional
+        Meta data for the whole dataset. Will end up in the dataset-wide attrs. Allowed
+        keys are "references", "rights", "contact", "title", "comment", "institution",
+        and "history". Documentation about the format and meaning of the meta data can
+        be found in the
+        `data format documentation <https://primap2.readthedocs.io/en/stable/data_format_details.html#dataset-attributes>`_.  # noqa: E501
+
+    time_format : str, optional
+        strftime style format used to format the time information for the data columns
+        in the interchange format.
+        Default: "%F", i.e. the ISO 8601 date format.
+
+    Returns
+    -------
+    obj: pd.DataFrame
+        pandas DataFrame with the read data
+
+    Examples
+    --------
+    *Example for meta_mapping*::
+
+        meta_mapping = {
+            'pyCPA_col_1': {'col_1_value_1_in': 'col_1_value_1_out',
+                            'col_1_value_2_in': 'col_1_value_2_out',
+                            },
+            'pyCPA_col_2': {'col_2_value_1_in': 'col_2_value_1_out',
+                            'col_2_value_2_in': 'col_2_value_2_out',
+                            },
+        }
+
+    *Example for filter_keep*::
+
+        filter_keep = {
+            'f_1': {'variable': ['CO2', 'CH4'], 'region': 'USA'},
+            'f_2': {'variable': 'N2O'}
+        }
+
+    This example filter keeps all CO2 and CH4 data for the USA and N2O data for all
+    countries
+
+    *Example for filter_remove*::
+
+        filter_remove = {
+            'f_1': {'scenario': 'HISTORY'},
+        }
+
+    This filter removes all data with 'HISTORY' as scenario
+
+    """
+    # Check and prepare arguments
+    if coords_defaults is None:
+        coords_defaults = {}
+    if meta_data is None:
+        attrs = {}
+    else:
+        attrs = meta_data.copy()
+
+    check_mandatory_dimensions(coords_cols, coords_defaults)
+    check_overlapping_specifications(coords_cols, coords_defaults)
+
+    filter_data(data_long, filter_keep, filter_remove)
+
+    add_dimensions_from_defaults(
+        data_long, coords_defaults, additional_allowed_coords=["time"]
+    )
+
+    naming_attrs = rename_columns(
+        data_long, coords_cols, coords_defaults, coords_terminologies
+    )
+
+    attrs.update(naming_attrs)
+
+    if coords_value_mapping is not None:
+        map_metadata(data_long, attrs=attrs, meta_mapping=coords_value_mapping)
+
+    if coords_value_filling is not None:
+        data_long = fill_from_other_col(
+            data_long, attrs=attrs, coords_value_filling=coords_value_filling
+        )
+
+    coords = list(set(data_long.columns.values) - {"data"})
+
+    harmonize_units(data_long, dimensions=coords, attrs=attrs)
+
+    data_long["time"] = pd.to_datetime(data_long["time"], format=time_format)
+
+    data, coords = long_to_wide(data_long, time_format=time_format)
+
+    data, coords = sort_columns_and_rows(data, dimensions=coords)
+
+    data.attrs = interchange_format_attrs_dict(
+        xr_attrs=attrs, time_format=time_format, dimensions=coords
+    )
+
+    return data
+
+
 def read_long_csv_file_if(
     filepath_or_buffer: Union[str, Path, IO],
     *,
@@ -539,6 +711,64 @@ def filter_data(
     data.reset_index(drop=True, inplace=True)
 
 
+def fill_from_other_col(
+    df: pd.DataFrame,
+    *,
+    coords_value_filling: Dict[str, Dict[str, Dict[str, str]]],
+    attrs: Dict[str, Any],
+) -> pd.DataFrame:
+    """
+    This function fills value in one column based on values in other columns.
+    It can be used to fill NaN values or to replace e.g. non-standard or
+    non-unique category codes based on category names. It operates on pandas
+    DataFrames.
+
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Data to operate on
+
+    coords_value_filling : dict
+        A dict with primap2 dimension names as keys. These are the target columns where
+        values will be filled (or replaced). Vales are dicts with primap2 dimension
+        names as keys. These are the source columns. The values are dicts with source
+        value - target value mappings.
+        This can be used to e.g. fill missing category codes based on category names or
+        to replace category codes which do not meet the terminology using the category
+        names.
+
+    attrs : dict
+        Dataset attributes
+
+    Returns
+    -------
+    pd.DataFrame
+    """
+    df_filled = df.copy()
+
+    dim_aliases = _alias_selection.translations_from_attrs(attrs, include_entity=True)
+
+    # loop over target columns in value mapping
+    for target_col in coords_value_filling:
+        target_info = coords_value_filling[target_col]
+        # loop over source columns
+        for source_col in target_info:
+            mapping_info = target_info[source_col]
+            # loop over cases
+            target_col_name = dim_aliases.get(target_col, target_col)
+            source_col_name = dim_aliases.get(source_col, source_col)
+            for source_value in mapping_info:
+                df_filled.loc[
+                    df_filled[source_col_name] == source_value, target_col_name
+                ] = df_filled.loc[
+                    df_filled[source_col_name] == source_value, target_col_name
+                ] = mapping_info[
+                    source_value
+                ]
+    return df_filled
+
+
 def add_dimensions_from_defaults(
     data: pd.DataFrame,
     coords_defaults: Dict[str, Any],
@@ -561,6 +791,23 @@ def add_dimensions_from_defaults(
 
 
 def map_metadata(
+    data: pd.DataFrame,
+    *,
+    meta_mapping: Dict[str, Union[str, Callable, dict]],
+    attrs: Dict[str, Any],
+):
+    """Map the metadata according to specifications given in meta_mapping.
+    First map entity, then the rest."""
+
+    if "entity" in meta_mapping.keys():
+        meta_mapping_entity = dict(entity=meta_mapping["entity"])
+        meta_mapping.pop("entity")
+        map_metadata_unordered(data, meta_mapping=meta_mapping_entity, attrs=attrs)
+
+    map_metadata_unordered(data, meta_mapping=meta_mapping, attrs=attrs)
+
+
+def map_metadata_unordered(
     data: pd.DataFrame,
     *,
     meta_mapping: Dict[str, Union[str, Callable, dict]],

--- a/primap2/pm2io/_interchange_format.py
+++ b/primap2/pm2io/_interchange_format.py
@@ -26,6 +26,7 @@ INTERCHANGE_FORMAT_COLUMN_ORDER = [
     "unit",
     "category",
     "orig_cat_name",
+    "cat_name_translation",
 ]
 
 # Pretty basic schema for now; attrs could be declared more explicitly with the

--- a/primap2/pm2io/_interchange_format.py
+++ b/primap2/pm2io/_interchange_format.py
@@ -25,6 +25,7 @@ INTERCHANGE_FORMAT_COLUMN_ORDER = [
     "entity",
     "unit",
     "category",
+    "orig_cat_name",
 ]
 
 # Pretty basic schema for now; attrs could be declared more explicitly with the

--- a/primap2/pm2io/_interchange_format.py
+++ b/primap2/pm2io/_interchange_format.py
@@ -36,6 +36,7 @@ INTERCHANGE_FORMAT_STRICTYAML_SCHEMA = sy.Map(
         "attrs": sy.MapPattern(sy.Str(), sy.Any()),
         "dimensions": sy.MapPattern(sy.Str(), sy.Seq(sy.Str())),
         "time_format": sy.Str(),
+        sy.Optional("additional_coordinates"): sy.MapPattern(sy.Str(), sy.Str()),
     }
 )
 
@@ -226,19 +227,44 @@ def from_interchange_format(
         xr dataset with the converted data
     """
     if attrs is None:
-        attrs = data.attrs
+        attrs = data.attrs.copy()
 
     if "entity_terminology" in attrs["attrs"]:
         entity_col = f"entity ({attrs['attrs']['entity_terminology']})"
     else:
         entity_col = "entity"
 
+    if "additional_coordinates" not in attrs:
+        attrs["additional_coordinates"] = {}
+
+    # build dicts for additional coordinates
+    add_coord_mapping_dicts = {}
+    for coord in attrs["additional_coordinates"].keys():
+        values = data[[coord, attrs["additional_coordinates"][coord]]]
+        values = values.drop_duplicates()
+        dim_values = list(values[attrs["additional_coordinates"][coord]])
+        coord_values = list(values[coord])
+        if len(coord_values) != len(set(dim_values)):
+            logger.error(
+                f"Different secondary coordinate values for given first coordinate "
+                f"value for {coord}."
+            )
+            raise ValueError(
+                f"Different secondary coordinate values for given first coordinate "
+                f"value for {coord}."
+            )
+
+        add_coord_mapping_dicts[coord] = dict(zip(dim_values, coord_values))
+
+    # drop additional coordinates. make a copy first to not alter input DF
+    data_drop = data.drop(columns=attrs["additional_coordinates"].keys(), inplace=False)
+
     # find the time columns
     if_index_cols = set(itertools.chain(*attrs["dimensions"].values()))
-    time_cols = set(data.columns.values) - if_index_cols
+    time_cols = set(data_drop.columns.values) - if_index_cols
 
     # convert to xarray
-    data_xr = data.to_xarray()
+    data_xr = data_drop.to_xarray()
     index_cols = if_index_cols - {"unit", "time"}
     data_xr = data_xr.set_index({"index": list(index_cols)})
     # take the units out as they increase dimensionality and we have only one unit per
@@ -293,6 +319,26 @@ def from_interchange_format(
         data_vars[entity] = da_entity.unstack("index")
 
     data_xr = xr.Dataset(data_vars)
+
+    # add the additional coordinates
+    for coord in attrs["additional_coordinates"].keys():
+        dim_values_xr = list(data_xr[attrs["additional_coordinates"][coord]].values)
+        coord_values_ordered = [
+            add_coord_mapping_dicts[coord][value] for value in dim_values_xr
+        ]
+        data_xr = data_xr.assign_coords(
+            {
+                coord: xr.DataArray(
+                    data=np.array(coord_values_ordered),
+                    coords={
+                        attrs["additional_coordinates"][coord]: data_xr.coords[
+                            attrs["additional_coordinates"][coord]
+                        ]
+                    },
+                    dims=[attrs["additional_coordinates"][coord]],
+                )
+            }
+        )
 
     # fill the entity/variable attributes
     for variable in data_xr:

--- a/primap2/tests/data/test_csv_data_category_name.csv
+++ b/primap2/tests/data/test_csv_data_category_name.csv
@@ -1,0 +1,3 @@
+country,category,category_name,gas,unit,1991,2000,2010
+AUS,IPC1,Energy,CO2,Gg,4.1,5,6
+ZAM,IPC2,IPPU,CH4,Mt,7,8,9

--- a/primap2/tests/data/test_csv_data_category_name_fill_cat_code.csv
+++ b/primap2/tests/data/test_csv_data_category_name_fill_cat_code.csv
@@ -1,0 +1,3 @@
+country,category,category_name,gas,unit,1991,2000,2010
+AUS,XX,Energy,CO2,Gg,4.1,5,6
+ZAM,XX,IPPU,CH4,Mt,7,8,9

--- a/primap2/tests/data/test_csv_data_category_name_long.csv
+++ b/primap2/tests/data/test_csv_data_category_name_long.csv
@@ -1,0 +1,7 @@
+country,category,category_name,gas,unit,year,emissions
+AUS,IPC1,Energy,CO2,Gg,1991,4.1
+ZAM,IPC2,IPPU,CH4,Mt,1991,7
+AUS,IPC1,Energy,CO2,Gg,2000,5
+ZAM,IPC2,IPPU,CH4,Mt,2000,8
+AUS,IPC1,Energy,CO2,Gg,2010,6
+ZAM,IPC2,IPPU,CH4,Mt,2010,9

--- a/primap2/tests/data/test_read_wide_csv_file_no_sec_cats_cat_name.csv
+++ b/primap2/tests/data/test_read_wide_csv_file_no_sec_cats_cat_name.csv
@@ -1,0 +1,3 @@
+,source,scenario (general),area (ISO3),entity,unit,category (IPCC2006),category_name,1991,2000,2010
+0,TESTcsv2021,HISTORY,AUS,CO2,Gg CO2 / yr,1,Energy,4.1,5.0,6.0
+1,TESTcsv2021,HISTORY,ZAM,CH4,Mt CH4 / yr,2,IPPU,7.0,8.0,9.0

--- a/primap2/tests/test_data_reading.py
+++ b/primap2/tests/test_data_reading.py
@@ -684,6 +684,39 @@ class TestInterchangeFormat:
             in caplog.text
         )
 
+    def test_from_add_coord_non_unique(self, caplog):
+        df = pd.DataFrame(
+            {
+                "a": np.arange(3),
+                "b": np.arange(3),
+                "c": np.arange(3),
+                "entity": ["CO2"] * 3,
+                "entity_name": ["Carbondioxide", "Carbondioxide", "Methane"],
+                "unit": ["Gg"] * 3,
+                "2001": np.arange(3),
+            }
+        )
+        df.attrs = {
+            "attrs": {},
+            "dimensions": {"CO2": ["a", "b", "c"]},
+            "time_format": "%Y",
+            "additional_coordinates": {"entity_name": "entity"},
+        }
+
+        with pytest.raises(
+            ValueError,
+            match="Different secondary coordinate values "
+            "for given first coordinate value for "
+            "entity_name.",
+        ):
+            pm2io.from_interchange_format(df)
+
+        assert "ERROR" in caplog.text
+        assert (
+            "Different secondary coordinate values for given first coordinate "
+            "value for entity_name." in caplog.text
+        )
+
     def test_roundtrip(self, tmp_path):
         file_input = DATA_PATH / "test_read_wide_csv_file_output.csv"
         file_temp = tmp_path / "test_interchange_format"

--- a/primap2/tests/test_data_reading.py
+++ b/primap2/tests/test_data_reading.py
@@ -9,6 +9,7 @@ import pytest
 import primap2
 import primap2.pm2io as pm2io
 import primap2.pm2io._conversion
+from primap2.pm2io._data_reading import additional_coordinate_metadata
 
 from .utils import assert_ds_aligned_equal
 
@@ -98,6 +99,18 @@ def coords_value_mapping():
         "category": "PRIMAP1",
         "entity": "PRIMAP1",
         "unit": "PRIMAP1",
+    }
+
+
+@pytest.fixture
+def coords_value_filling():
+    return {
+        "category": {  # col to fill
+            "category_name": {  # col to fill from
+                "Energy": "1",  # from value: to value
+                "IPPU": "2",
+            }
+        }
     }
 
 
@@ -246,6 +259,61 @@ class TestReadWideCSVFile:
             coords_defaults=coords_defaults,
             coords_terminologies=coords_terminologies,
             coords_value_mapping=coords_value_mapping,
+        )
+        attrs_result = df_result.attrs
+        df_result.to_csv(tmp_path / "temp.csv")
+        df_result = pd.read_csv(tmp_path / "temp.csv", index_col=0)
+        pd.testing.assert_frame_equal(df_result, df_expected, check_column_type=False)
+
+        attrs_expected = {
+            "attrs": {
+                "scen": "scenario (general)",
+                "area": "area (ISO3)",
+                "cat": "category (IPCC2006)",
+            },
+            "time_format": "%Y",
+            "dimensions": {
+                "*": [
+                    "entity",
+                    "source",
+                    "area (ISO3)",
+                    "unit",
+                    "scenario (general)",
+                    "category (IPCC2006)",
+                ]
+            },
+            "additional_coordinates": {"category_name": "category (IPCC2006)"},
+        }
+
+        assert_attrs_equal(attrs_result, attrs_expected)
+
+    def test_read_wide_fill_col(
+        self,
+        tmp_path,
+        coords_cols,
+        add_coords_cols,
+        coords_defaults,
+        coords_terminologies,
+        coords_value_mapping,
+        coords_value_filling,
+    ):
+        file_input = DATA_PATH / "test_csv_data_category_name_fill_cat_code.csv"
+        file_expected = DATA_PATH / "test_read_wide_csv_file_no_sec_cats_cat_name.csv"
+        df_expected = pd.read_csv(file_expected, index_col=0)
+
+        del coords_cols["sec_cats__Class"]
+        del coords_defaults["sec_cats__Type"]
+        del coords_terminologies["sec_cats__Class"]
+        del coords_terminologies["sec_cats__Type"]
+
+        df_result = pm2io.read_wide_csv_file_if(
+            file_input,
+            coords_cols=coords_cols,
+            add_coords_cols=add_coords_cols,
+            coords_defaults=coords_defaults,
+            coords_terminologies=coords_terminologies,
+            coords_value_mapping=coords_value_mapping,
+            coords_value_filling=coords_value_filling,
         )
         attrs_result = df_result.attrs
         df_result.to_csv(tmp_path / "temp.csv")
@@ -924,6 +992,40 @@ class TestLong:
         )
 
         pd.testing.assert_frame_equal(df, df_expected)
+
+
+class TestAdditionalCoordinateMetadata:
+    def test_error_coord_terminology(self):
+        add_coords_cols = {"category_name": ["cat_name", "category"]}
+        coords_cols = {"category": "cat_code"}
+        coords_terminologies = {"category_name": "IPCC2006_name"}
+
+        with pytest.raises(
+            ValueError,
+            match="Additional coordinate category_name has terminology definition. "
+            "This is currently not supported by PRIMAP2.",
+        ):
+            additional_coordinate_metadata(
+                coords_cols=coords_cols,
+                add_coords_cols=add_coords_cols,
+                coords_terminologies=coords_terminologies,
+            )
+
+    def test_error_coord_not_present(self):
+        add_coords_cols = {"category_name": ["cat_name", "category"]}
+        coords_cols = {"entity": "entity"}
+        coords_terminologies = {}
+
+        with pytest.raises(
+            ValueError,
+            match="Additional coordinate category_name refers to unknown "
+            "coordinate category",
+        ):
+            additional_coordinate_metadata(
+                coords_cols=coords_cols,
+                add_coords_cols=add_coords_cols,
+                coords_terminologies=coords_terminologies,
+            )
 
 
 # functions that still need individual testing

--- a/primap2/tests/test_data_reading.py
+++ b/primap2/tests/test_data_reading.py
@@ -68,6 +68,11 @@ def coords_cols():
 
 
 @pytest.fixture
+def add_coords_cols():
+    return {"category_name": ["category_name", "category"]}
+
+
+@pytest.fixture
 def coords_defaults():
     return {
         "source": "TESTcsv2021",
@@ -220,6 +225,7 @@ class TestReadWideCSVFile:
         self,
         tmp_path,
         coords_cols,
+        add_coords_cols,
         coords_defaults,
         coords_terminologies,
         coords_value_mapping,
@@ -232,7 +238,6 @@ class TestReadWideCSVFile:
         del coords_defaults["sec_cats__Type"]
         del coords_terminologies["sec_cats__Class"]
         del coords_terminologies["sec_cats__Type"]
-        add_coords_cols = {"category_name": ["category_name", "category"]}
 
         df_result = pm2io.read_wide_csv_file_if(
             file_input,
@@ -772,6 +777,46 @@ class TestLong:
         df_result_long = pm2io.read_long_csv_file_if(
             file_input_long,
             coords_cols=coords_cols,
+            coords_defaults=coords_defaults,
+            coords_terminologies=coords_terminologies,
+            coords_value_mapping=coords_value_mapping,
+            time_format="%Y",
+        )
+
+        pd.testing.assert_frame_equal(df_result_wide, df_result_long)
+        assert df_result_wide.attrs == df_result_long.attrs
+
+    def test_compare_wide_add_cols(
+        self,
+        coords_cols,
+        add_coords_cols,
+        coords_defaults,
+        coords_terminologies,
+        coords_value_mapping,
+    ):
+        file_input_wide = DATA_PATH / "test_csv_data_category_name.csv"
+        file_input_long = DATA_PATH / "test_csv_data_category_name_long.csv"
+
+        del coords_cols["sec_cats__Class"]
+        del coords_defaults["sec_cats__Type"]
+        del coords_terminologies["sec_cats__Class"]
+        del coords_terminologies["sec_cats__Type"]
+
+        df_result_wide = pm2io.read_wide_csv_file_if(
+            file_input_wide,
+            coords_cols=coords_cols,
+            add_coords_cols=add_coords_cols,
+            coords_defaults=coords_defaults,
+            coords_terminologies=coords_terminologies,
+            coords_value_mapping=coords_value_mapping,
+        )
+
+        coords_cols["time"] = "year"
+        coords_cols["data"] = "emissions"
+        df_result_long = pm2io.read_long_csv_file_if(
+            file_input_long,
+            coords_cols=coords_cols,
+            add_coords_cols=add_coords_cols,
             coords_defaults=coords_defaults,
             coords_terminologies=coords_terminologies,
             coords_value_mapping=coords_value_mapping,

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     matplotlib
     ruamel.yaml
     strictyaml
+    openpyxl
 
 [options.extras_require]
 test =


### PR DESCRIPTION
…columns and metadata to interchnage format

small changes and fixed to primap1 related mapping functions (allow more flexible unit input, map entities before units to ensure correct unit mapping)

# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in ``CHANGELOG.rst`` added

## Description

Please provide a short description what your pull request does.
