### PR TITLE
Unconditionally remove generated folder before building docs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ coverage: venv ## check code coverage quickly with the default Python
 	ls htmlcov/index.html
 
 docs: venv ## generate Sphinx HTML documentation, including API docs
+	rm -rf docs/generated
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 


### PR DESCRIPTION
Less warnings.
