### PR TITLE
Fix building of docs at RTD

### DIFF
--- a/changelog_unreleased/doc-fixes.rst
+++ b/changelog_unreleased/doc-fixes.rst
@@ -1,0 +1,1 @@
+* change to stable sphinx-autosummary-accessors version.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,6 @@ numpy
 pandas
 openscm_units
 loguru
-git+https://github.com/keewis/sphinx-autosummary-accessors
+git+https://github.com/xarray-contrib/sphinx-autosummary-accessors@stable
 numpydoc
 matplotlib


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

readthedocs builds are currently failing, and I try to find out why.
