### PR TITLE
Replace hacks that worked on old versions of xarray with proper xarray calls

### DIFF
--- a/changelog_unreleased/new-xarray-compat.rst
+++ b/changelog_unreleased/new-xarray-compat.rst
@@ -1,0 +1,3 @@
+* The latest (not-yet-released) version of xarray contains a rework of indexing
+  and some small changes to our I/O functions are necessary to support both old
+  and new xarray.

--- a/primap2/_setters.py
+++ b/primap2/_setters.py
@@ -276,7 +276,7 @@ class DataArraySettersAccessor(_accessor_base.BaseDataArrayAccessor):
             # to broadcast value only to sel, but would need more careful handling
             # later.
             if new == "extend":
-                value, expanded = xr.broadcast(value, self._da)
+                expanded, value = xr.broadcast(self._da, value)
             else:
                 expanded = self._da
                 value = value.broadcast_like(expanded)


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

The latest (not-yet-released) version of xarray contains a [rework of indexing](https://github.com/pydata/xarray/pull/5692) and some small changes to our I/O functions are necessary to support both old and new xarray.