### PR TITLE
Fix gas basket functions + python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 formats: all
+
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: "3.10"
   install:
     - requirements: docs/requirements.txt
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 formats: all
 python:
-  version: 3
+  version: "3.10"
   install:
     - requirements: docs/requirements.txt
   system_packages: true

--- a/changelog_unreleased/fix-gas-basket-functions.rst
+++ b/changelog_unreleased/fix-gas-basket-functions.rst
@@ -1,0 +1,8 @@
+* Change behaviour of gas basket aggregation functions to be the same as
+  other aggregation functions.
+  Now, `ds.pr.gas_basket_contents_sum()` and
+  `ds.pr.fill_na_gas_basket_from_contents()` work like `ds.pr.sum()`.
+  Both now have a `skipna` argument, and operate as if `skipna=True`
+  by default.
+  Note that this is a breaking change, by default NaNs are now
+  treated as zero values when aggregating gas baskets!

--- a/changelog_unreleased/python.3.10.rst
+++ b/changelog_unreleased/python.3.10.rst
@@ -1,0 +1,1 @@
+* Drop python 3.7 support and add python 3.10 support following NEP 29.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,9 @@
 -e .
-sphinx==4.0.2
-ipykernel
+Sphinx>=4.2
+sphinx-rtd-theme
 nbsphinx
-xarray
-pint
-pint_xarray
-numpy
-pandas
-openscm_units
-loguru
-git+https://github.com/xarray-contrib/sphinx-autosummary-accessors@stable
+numpydoc
+ipykernel
+sphinx-autosummary-accessors
 numpydoc
 matplotlib

--- a/primap-stubs.patch
+++ b/primap-stubs.patch
@@ -1,40 +1,40 @@
-diff -r -u xarray-orig/core/dataarray.pyi xarray/core/dataarray.pyi
---- xarray-orig/core/dataarray.pyi	2021-02-01 17:35:25.202167080 +0100
-+++ xarray/core/dataarray.pyi	2021-02-01 17:36:56.462279968 +0100
-@@ -1,6 +1,7 @@
- import datetime
- import numpy as np
- import pandas as pd
+diff '--color=auto' -r -u xarray-orig/core/dataarray.pyi xarray/core/dataarray.pyi
+--- xarray-orig/core/dataarray.pyi	2022-05-09 19:44:00.059497745 +0200
++++ xarray/core/dataarray.pyi	2022-05-09 19:45:46.028378457 +0200
+@@ -26,6 +26,7 @@
+ from dask.delayed import Delayed
+ from iris.cube import Cube as iris_Cube
+ from typing import Any, Callable, Hashable, Iterable, Literal, Mapping, Sequence
 +import primap2
- from . import computation as computation, dtypes as dtypes, groupby as groupby, indexing as indexing, ops as ops, pdcompat as pdcompat, resample as resample, rolling as rolling, utils as utils, weighted as weighted
- from .accessor_dt import CombinedDatetimelikeAccessor as CombinedDatetimelikeAccessor
- from .accessor_str import StringAccessor as StringAccessor
-@@ -34,6 +35,8 @@
-     def __init__(self, data: Any=..., coords: Union[Sequence[Tuple], Mapping[Hashable, Any], None]=..., dims: Union[Hashable, Sequence[Hashable], None]=..., name: Hashable=..., attrs: Mapping=..., indexes: Dict[Hashable, pd.Index]=..., fastpath: bool=...) -> None: ...
-     def to_dataset(self, dim: Hashable=..., *, name: Hashable=..., promote_attrs: bool=...) -> Dataset: ...
-     @property
-+    def pr(self) -> primap2.accessors.PRIMAP2DataArrayAccessor: ...
-+    @property
-     def name(self) -> Optional[Hashable]: ...
-     @name.setter
-     def name(self, value: Optional[Hashable]) -> None: ...
-diff -r -u xarray-orig/core/dataset.pyi xarray/core/dataset.pyi
---- xarray-orig/core/dataset.pyi	2021-02-01 17:35:25.202167080 +0100
-+++ xarray/core/dataset.pyi	2021-02-01 17:36:56.482279994 +0100
-@@ -1,6 +1,7 @@
- import datetime
- import numpy as np
- import pandas as pd
-+import primap2
- from . import alignment as alignment, dtypes as dtypes, duck_array_ops as duck_array_ops, formatting as formatting, formatting_html as formatting_html, groupby as groupby, ops as ops, resample as resample, rolling as rolling, utils as utils, weighted as weighted
- from ..backends import AbstractDataStore as AbstractDataStore, ZarrStore as ZarrStore
- from .alignment import align as align
-@@ -44,6 +45,8 @@
 
- class Dataset(Mapping, ImplementsDatasetReduce, DataWithCoords):
-     def __init__(self, data_vars: Mapping[Hashable, Any]=..., coords: Mapping[Hashable, Any]=..., attrs: Mapping[Hashable, Any]=...) -> None: ...
+ class _LocIndexer:
+     data_array: Incomplete
+@@ -36,6 +37,8 @@
+ class DataArray(AbstractArray, DataWithCoords, DataArrayArithmetic):
+     dt: Incomplete
+     def __init__(self, data: Any = ..., coords: Union[Sequence[tuple], Mapping[Any, Any], None] = ..., dims: Union[Hashable, Sequence[Hashable], None] = ..., name: Hashable = ..., attrs: Mapping = ..., indexes: dict[Hashable, pd.Index] = ..., fastpath: bool = ...) -> None: ...
++    @property
++    def pr(self) -> primap2.accessors.PRIMAP2DataArrayAccessor: ...
+     def to_dataset(self, dim: Hashable = ..., *, name: Hashable = ..., promote_attrs: bool = ...) -> Dataset: ...
+     @property
+     def name(self) -> Union[Hashable, None]: ...
+diff '--color=auto' -r -u xarray-orig/core/dataset.pyi xarray/core/dataset.pyi
+--- xarray-orig/core/dataset.pyi	2022-05-09 19:44:00.059497745 +0200
++++ xarray/core/dataset.pyi	2022-05-09 19:45:37.980311296 +0200
+@@ -27,6 +27,7 @@
+ from numbers import Number
+ from os import PathLike
+ from typing import Any, Callable, Collection, Hashable, Iterable, Iterator, Literal, Mapping, MutableMapping, Sequence, overload
++import primap2
+
+ def calculate_dimensions(variables: Mapping[Any, Variable]) -> dict[Hashable, int]: ...
+ def merge_indexes(indexes: Mapping[Any, Union[Hashable, Sequence[Hashable]]], variables: Mapping[Any, Variable], coord_names: set[Hashable], append: bool = ...) -> tuple[dict[Hashable, Variable], set[Hashable]]: ...
+@@ -50,6 +51,8 @@
+
+ class Dataset(DataWithCoords, DatasetArithmetic, Mapping):
+     def __init__(self, data_vars: Mapping[Any, Any] = ..., coords: Mapping[Any, Any] = ..., attrs: Mapping[Any, Any] = ...) -> None: ...
 +    @property
 +    def pr(self) -> primap2.accessors.PRIMAP2DatasetAccessor: ...
      @classmethod
-     def load_store(cls: Any, store: Any, decoder: Any=...) -> Dataset: ...
+     def load_store(cls, store, decoder: Incomplete | None = ...) -> Dataset: ...
      @property

--- a/primap2/_aggregate.py
+++ b/primap2/_aggregate.py
@@ -371,7 +371,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
           equivalent to giving ``dim=set(da.dims) + {"entity"} - {"dim_1"}``, but more
           legible.
         skipna: bool, optional
-          If True, skip missing values (as marked by NaN). By default, only
+          If True (default), skip missing values (as marked by NaN). By default, only
           skips missing values for float dtypes; other dtypes either do not
           have a sentinel missing value (int) or skipna=True has not been
           implemented (object, datetime64 or timedelta64).
@@ -425,6 +425,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         *,
         basket: str,
         basket_contents: Sequence[str],
+        skipna: Optional[bool] = None,
         skipna_evaluation_dims: Optional[DimOrDimsT] = None,
     ) -> xr.DataArray:
         """The sum of gas basket contents converted using the global warming potential
@@ -437,9 +438,17 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         basket_contents: list of str
           The name of the gases in the gas basket. The sum of all basket_contents
           equals the basket. Values from `ds.keys()`.
-        skipna_evaluation_dims: list of str, optional
-          Dimensions which should be evaluated to determine if NA values should be
-          skipped entirely if missing fully. By default, all NA values are skipped.
+        skipna: bool, optional
+          If True (default), skip missing values (as marked by NaN). By default, only
+          skips missing values for float dtypes; other dtypes either do not
+          have a sentinel missing value (int) or skipna=True has not been
+          implemented (object, datetime64 or timedelta64).
+        skipna_evaluation_dims: str or list of str, optional
+          Dimension(s) to evaluate along to determine if values should be skipped.
+          Only one of ``skipna`` and ``skipna_evaluation_dims`` can be supplied.
+          If all values along the specified dimensions are NA, the values are skipped,
+          other NA values are not skipped and will lead to NA in the corresponding
+          result.
 
         Returns
         -------
@@ -453,7 +462,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
             basket_contents_converted[var] = da.pr.convert_to_gwp_like(like=basket_da)
 
         da = basket_contents_converted.pr.sum(
-            dim="entity", skipna_evaluation_dims=skipna_evaluation_dims
+            dim="entity",
+            skipna_evaluation_dims=skipna_evaluation_dims,
+            skipna=skipna,
         )
         da.attrs["gwp_context"] = basket_da.attrs["gwp_context"]
         da.attrs["entity"] = basket_da.attrs["entity"]
@@ -466,6 +477,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         basket: str,
         basket_contents: Sequence[str],
         sel: Optional[Mapping[Hashable, Sequence]] = None,
+        skipna: Optional[bool] = None,
         skipna_evaluation_dims: Optional[DimOrDimsT] = None,
     ) -> xr.DataArray:
         """Fill NA values in a gas basket using the sum of its contents.
@@ -484,9 +496,17 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
           If the filling should only be done on a subset of the Dataset while
           retaining all other values unchanged, give a selection dictionary. The
           filling will be done on `ds.loc[sel]`.
-        skipna_evaluation_dims: list of str, optional
-          Dimensions which should be evaluated to determine if NA values should be
-          skipped entirely if missing fully. By default, all NA values are skipped.
+        skipna: bool, optional
+          If True (default), skip missing values (as marked by NaN). By default, only
+          skips missing values for float dtypes; other dtypes either do not
+          have a sentinel missing value (int) or skipna=True has not been
+          implemented (object, datetime64 or timedelta64).
+        skipna_evaluation_dims: str or list of str, optional
+          Dimension(s) to evaluate along to determine if values should be skipped.
+          Only one of ``skipna`` and ``skipna_evaluation_dims`` can be supplied.
+          If all values along the specified dimensions are NA, the values are skipped,
+          other NA values are not skipped and will lead to NA in the corresponding
+          result.
 
         Returns
         -------
@@ -498,5 +518,6 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
                 basket=basket,
                 basket_contents=basket_contents,
                 skipna_evaluation_dims=skipna_evaluation_dims,
+                skipna=skipna,
             )
         )

--- a/primap2/_aggregate.py
+++ b/primap2/_aggregate.py
@@ -425,7 +425,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         *,
         basket: str,
         basket_contents: Sequence[str],
-        skipna_evaluation_dims: Sequence[str] = tuple(),
+        skipna_evaluation_dims: Optional[DimOrDimsT] = None,
     ) -> xr.DataArray:
         """The sum of gas basket contents converted using the global warming potential
         of the gas basket.
@@ -439,7 +439,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
           equals the basket. Values from `ds.keys()`.
         skipna_evaluation_dims: list of str, optional
           Dimensions which should be evaluated to determine if NA values should be
-          skipped entirely if missing fully. By default, no NA values are skipped.
+          skipped entirely if missing fully. By default, all NA values are skipped.
 
         Returns
         -------
@@ -466,7 +466,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         basket: str,
         basket_contents: Sequence[str],
         sel: Optional[Mapping[Hashable, Sequence]] = None,
-        skipna_evaluation_dims: Sequence[str] = tuple(),
+        skipna_evaluation_dims: Optional[DimOrDimsT] = None,
     ) -> xr.DataArray:
         """Fill NA values in a gas basket using the sum of its contents.
 
@@ -486,7 +486,7 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
           filling will be done on `ds.loc[sel]`.
         skipna_evaluation_dims: list of str, optional
           Dimensions which should be evaluated to determine if NA values should be
-          skipped entirely if missing fully. By default, no NA values are skipped.
+          skipped entirely if missing fully. By default, all NA values are skipped.
 
         Returns
         -------

--- a/primap2/tests/test_aggregate.py
+++ b/primap2/tests/test_aggregate.py
@@ -269,13 +269,13 @@ class TestGasBasket:
         ] = np.nan * ureg("Gg CO2 / year")
         return partly_nan_ds
 
-    def test_fill_na_from_contents_skipna_evaluation_dims(self, partly_nan_ds):
-        filled = partly_nan_ds.pr.fill_na_gas_basket_from_contents(
+    def test_fill_na_from_contents_skipna_evaluation_dims(self, partly_filled_ds):
+        filled = partly_filled_ds.pr.fill_na_gas_basket_from_contents(
             basket="KYOTOGHG (AR4GWP100)",
             basket_contents=["CO2", "SF6", "CH4"],
             skipna_evaluation_dims=("time",),
         )
-        expected = partly_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected = partly_filled_ds["KYOTOGHG (AR4GWP100)"].copy()
         expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6) * ureg("Gg CO2 / year")
         expected.loc[{"area (ISO3)": "BOL", "time": "2020"}] = (
             1 + self.sf6 + self.ch4

--- a/primap2/tests/test_aggregate.py
+++ b/primap2/tests/test_aggregate.py
@@ -204,79 +204,117 @@ class TestCount:
         xr.testing.assert_allclose(actual, expected)
 
 
-def test_gas_basket_contents_sum(empty_ds):
-    empty_ds["CO2"][:] = 1 * ureg("Gg CO2 / year")
-    empty_ds["SF6"][:] = 1 * ureg("Gg SF6 / year")
-    empty_ds["CH4"][:] = 1 * ureg("Gg CH4 / year")
-    empty_ds["CH4"].loc[{"area (ISO3)": "COL"}] = np.nan * ureg("Gg CH4 / year")
-
-    summed = empty_ds.pr.gas_basket_contents_sum(
-        basket="KYOTOGHG (AR4GWP100)",
-        basket_contents=["CO2", "SF6", "CH4"],
-        skipna_evaluation_dims=("time",),
-    )
-    expected = empty_ds["KYOTOGHG (AR4GWP100)"].copy()
+class TestGasBasket:
+    # AR4GWP100 values
     sf6 = 22_800
     ch4 = 25
-    expected[:] = (1 + sf6 + ch4) * ureg("Gg CO2 / year")
-    expected.loc[{"area (ISO3)": "COL"}] = (1 + sf6) * ureg("Gg CO2 / year")
-    assert_equal(summed, expected)
 
-    summed = empty_ds.pr.gas_basket_contents_sum(
-        basket="KYOTOGHG (AR4GWP100)",
-        basket_contents=["CO2", "SF6", "CH4"],
-    )
-    expected = empty_ds["KYOTOGHG (AR4GWP100)"].copy()
-    expected[:] = (1 + sf6 + ch4) * ureg("Gg CO2 / year")
-    expected.loc[{"area (ISO3)": "COL"}] = np.nan * ureg("Gg CO2 / year")
-    assert_equal(summed, expected, equal_nan=True)
+    @pytest.fixture
+    def partly_nan_ds(self, empty_ds):
+        empty_ds["CO2"][:] = 1 * ureg("Gg CO2 / year")
+        empty_ds["SF6"][:] = 1 * ureg("Gg SF6 / year")
+        empty_ds["CH4"][:] = 1 * ureg("Gg CH4 / year")
+        empty_ds["CH4"].loc[{"area (ISO3)": "COL"}] = np.nan * ureg("Gg CH4 / year")
+        return empty_ds
 
-
-def test_fill_na_gas_basket_from_contents(empty_ds):
-    empty_ds["CO2"][:] = 1 * ureg("Gg CO2 / year")
-    empty_ds["SF6"][:] = 1 * ureg("Gg SF6 / year")
-    empty_ds["CH4"][:] = 1 * ureg("Gg CH4 / year")
-    empty_ds["CH4"].loc[{"area (ISO3)": "COL"}] = np.nan * ureg("Gg CH4 / year")
-    empty_ds["KYOTOGHG (AR4GWP100)"][:] = 1 * ureg("Gg CO2 / year")
-    empty_ds["KYOTOGHG (AR4GWP100)"].loc[{"area (ISO3)": "COL"}] = np.nan * ureg(
-        "Gg CO2 / year"
-    )
-    empty_ds["KYOTOGHG (AR4GWP100)"].loc[
-        {"area (ISO3)": "BOL", "time": "2020"}
-    ] = np.nan * ureg("Gg CO2 / year")
-
-    filled = empty_ds.pr.fill_na_gas_basket_from_contents(
-        basket="KYOTOGHG (AR4GWP100)",
-        basket_contents=["CO2", "SF6", "CH4"],
-        skipna_evaluation_dims=("time",),
-    )
-    expected = empty_ds["KYOTOGHG (AR4GWP100)"].copy()
-    sf6 = 22_800
-    ch4 = 25
-    expected.loc[{"area (ISO3)": "COL"}] = (1 + sf6) * ureg("Gg CO2 / year")
-    expected.loc[{"area (ISO3)": "BOL", "time": "2020"}] = (1 + sf6 + ch4) * ureg(
-        "Gg CO2 / year"
-    )
-    assert_equal(filled, expected)
-
-    filled = empty_ds.pr.fill_na_gas_basket_from_contents(
-        basket="KYOTOGHG (AR4GWP100)",
-        basket_contents=["CO2", "SF6", "CH4"],
-        sel={"area (ISO3)": ["BOL"]},
-        skipna_evaluation_dims=("time",),
-    )
-    expected = empty_ds["KYOTOGHG (AR4GWP100)"].copy()
-    expected.loc[{"area (ISO3)": "BOL", "time": "2020"}] = (1 + sf6 + ch4) * ureg(
-        "Gg CO2 / year"
-    )
-    assert_equal(filled, expected, equal_nan=True)
-
-    with pytest.raises(
-        ValueError, match="The dimension of the selection doesn't match the dimension"
-    ):
-        empty_ds.pr.fill_na_gas_basket_from_contents(
+    def test_contents_sum_default(self, partly_nan_ds):
+        summed = partly_nan_ds.pr.gas_basket_contents_sum(
             basket="KYOTOGHG (AR4GWP100)",
             basket_contents=["CO2", "SF6", "CH4"],
-            sel={"area (ISO3)": "BOL"},
+        )
+        expected = partly_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected[:] = (1 + self.sf6 + self.ch4) * ureg("Gg CO2 / year")
+        # NaN counted as 0
+        expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6) * ureg("Gg CO2 / year")
+        assert_equal(summed, expected)
+
+    def test_contents_sum_skipna_evaluation_dims(self, partly_nan_ds):
+        partly_nan_ds["CH4"].loc[
+            {"area (ISO3)": "ARG", "time": "2012"}
+        ] = np.nan * ureg("Gg CH4 / year")
+        summed = partly_nan_ds.pr.gas_basket_contents_sum(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
             skipna_evaluation_dims=("time",),
         )
+        expected = partly_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected[:] = (1 + self.sf6 + self.ch4) * ureg("Gg CO2 / year")
+        # NaN only skipped where all time points NaN
+        expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6) * ureg("Gg CO2 / year")
+        expected.loc[{"area (ISO3)": "ARG", "time": "2012"}] = np.nan * ureg(
+            "Gg CO2 / year"
+        )
+        assert_equal(summed, expected, equal_nan=True)
+
+    def test_contents_sum_skipna(self, partly_nan_ds):
+        summed = partly_nan_ds.pr.gas_basket_contents_sum(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
+            skipna=False,
+        )
+        expected = partly_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected[:] = (1 + self.sf6 + self.ch4) * ureg("Gg CO2 / year")
+        # NaNs not skipped
+        expected.loc[{"area (ISO3)": "COL"}] = np.nan * ureg("Gg CO2 / year")
+        assert_equal(summed, expected, equal_nan=True)
+
+    @pytest.fixture
+    def partly_filled_ds(self, partly_nan_ds):
+        partly_nan_ds["KYOTOGHG (AR4GWP100)"][:] = 1 * ureg("Gg CO2 / year")
+        partly_nan_ds["KYOTOGHG (AR4GWP100)"].loc[
+            {"area (ISO3)": "COL"}
+        ] = np.nan * ureg("Gg CO2 / year")
+        partly_nan_ds["KYOTOGHG (AR4GWP100)"].loc[
+            {"area (ISO3)": "BOL", "time": "2020"}
+        ] = np.nan * ureg("Gg CO2 / year")
+        return partly_nan_ds
+
+    def test_fill_na_from_contents_skipna_evaluation_dims(self, partly_nan_ds):
+        filled = partly_nan_ds.pr.fill_na_gas_basket_from_contents(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
+            skipna_evaluation_dims=("time",),
+        )
+        expected = partly_nan_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected.loc[{"area (ISO3)": "COL"}] = (1 + self.sf6) * ureg("Gg CO2 / year")
+        expected.loc[{"area (ISO3)": "BOL", "time": "2020"}] = (
+            1 + self.sf6 + self.ch4
+        ) * ureg("Gg CO2 / year")
+        assert_equal(filled, expected)
+
+    def test_fill_na_from_contents_sel(self, partly_filled_ds):
+        filled = partly_filled_ds.pr.fill_na_gas_basket_from_contents(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
+            sel={"area (ISO3)": ["BOL"]},
+            skipna_evaluation_dims=("time",),
+        )
+        expected = partly_filled_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected.loc[{"area (ISO3)": "BOL", "time": "2020"}] = (
+            1 + self.sf6 + self.ch4
+        ) * ureg("Gg CO2 / year")
+        assert_equal(filled, expected, equal_nan=True)
+
+        with pytest.raises(
+            ValueError,
+            match="The dimension of the selection doesn't match the dimension",
+        ):
+            partly_filled_ds.pr.fill_na_gas_basket_from_contents(
+                basket="KYOTOGHG (AR4GWP100)",
+                basket_contents=["CO2", "SF6", "CH4"],
+                sel={"area (ISO3)": "BOL"},
+                skipna_evaluation_dims=("time",),
+            )
+
+    def test_fill_na_from_contents_skipna(self, partly_filled_ds):
+        filled = partly_filled_ds.pr.fill_na_gas_basket_from_contents(
+            basket="KYOTOGHG (AR4GWP100)",
+            basket_contents=["CO2", "SF6", "CH4"],
+            skipna=False,
+        )
+        expected = partly_filled_ds["KYOTOGHG (AR4GWP100)"].copy()
+        expected.loc[{"area (ISO3)": "COL"}] = np.nan * ureg("Gg CO2 / year")
+        expected.loc[{"area (ISO3)": "BOL", "time": "2020"}] = (
+            1 + self.sf6 + self.ch4
+        ) * ureg("Gg CO2 / year")
+        assert_equal(filled, expected, equal_nan=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ dev =
     build
     flake8
     coverage
-    Sphinx==4.0.2
+    Sphinx>=4.2
     sphinx-rtd-theme
     twine
     pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,9 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 license = Apache Software License 2.0
 license_file = LICENSE
 
@@ -28,7 +28,7 @@ packages =
     primap2.pm2io
     primap2.tests
     primap2.tests.data
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py38, py39, py310
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39
+envlist = py37, py38, py39, py310
 
 [testenv]
 deps =


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

* Change behaviour of gas basket aggregation functions to be the same as
  other aggregation functions.
  Now, `ds.pr.gas_basket_contents_sum()` and
  `ds.pr.fill_na_gas_basket_from_contents()` work like `ds.pr.sum()`.
  Both now have a `skipna` argument, and operate as if `skipna=True`
  by default.
  Note that this is a breaking change, by default NaNs are now
  treated as zero values when aggregating gas baskets!
* Drop python 3.7 support and add python 3.10 support following NEP 29.

