### PR TITLE
Drop python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [ 3.9, "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v2
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
   - repo: https://github.com/psf/black
-    rev: '23.1.0'
+    rev: '23.3.0'
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: '1.6.4'
+    rev: '1.7.0'
     hooks:
       - id: nbqa-black
         args: [ --nbqa-mutate, --line-length=75 ]

--- a/changelog_unreleased/drop_python_3.8.rst
+++ b/changelog_unreleased/drop_python_3.8.rst
@@ -1,1 +1,2 @@
-* Drop support for Python version 3.8 to prepare for it being dropped in Numpy on April 14.
+* Drop support for Python version 3.8 to prepare for it being dropped
+  in Numpy on April 14.

--- a/changelog_unreleased/drop_python_3.8.rst
+++ b/changelog_unreleased/drop_python_3.8.rst
@@ -1,0 +1,1 @@
+* Drop support for Python version 3.8 to prepare for it being dropped in Numpy on April 14.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ release = primap2.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -131,7 +131,7 @@ dubiously building ASCII art in Python or whatever), use
 `the fmt on/off directive <https://github.com/psf/black#the-black-code-style>`_ so black
 will ignore that part.
 
-We target Python version 3.6 and later, so using
+We target Python version 3.9 and later, so using
 `f-strings <https://docs.python.org/3/tutorial/inputoutput.html#tut-f-strings>`_ is fine
 and generally preferable to old-style format strings.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -29,7 +28,7 @@ packages =
     primap2.pm2io
     primap2.tests
     primap2.tests.data
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py38, py39, py310, py311
+envlist = py39, py310, py311
 
 [testenv]
 deps =


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

Drop support for python 3.8. It is due to be dropped by numpy on April 14 (see [NEP 29 support table](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table)) and we see CI failures already.
