### PR TITLE
Remove python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ 3.9, "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v2
 

--- a/changelog_unreleased/no-python39.rst
+++ b/changelog_unreleased/no-python39.rst
@@ -1,0 +1,1 @@
+* Removed Python 3.9 support.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -131,7 +131,7 @@ dubiously building ASCII art in Python or whatever), use
 `the fmt on/off directive <https://github.com/psf/black#the-black-code-style>`_ so black
 will ignore that part.
 
-We target Python version 3.9 and later, so using
+We target Python version 3.10 and later, so using
 `f-strings <https://docs.python.org/3/tutorial/inputoutput.html#tut-f-strings>`_ is fine
 and generally preferable to old-style format strings.
 

--- a/primap2/_aggregate.py
+++ b/primap2/_aggregate.py
@@ -1,5 +1,5 @@
 from collections.abc import Hashable, Iterable, Mapping, Sequence
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import xarray as xr
@@ -17,7 +17,7 @@ def dim_names(obj: DatasetOrDataArray):
 
 
 def select_no_scalar_dimension(
-    obj: DatasetOrDataArray, sel: Optional[Mapping[Hashable, Any]]
+    obj: DatasetOrDataArray, sel: Mapping[Hashable, Any] | None
 ) -> DatasetOrDataArray:
     """Select but raise an error if the selection produces a new scalar dimensions.
 
@@ -48,8 +48,8 @@ def select_no_scalar_dimension(
 
 class DataArrayAggregationAccessor(BaseDataArrayAccessor):
     def _reduce_dim(
-        self, dim: Optional[DimOrDimsT], reduce_to_dim: Optional[DimOrDimsT]
-    ) -> Optional[DimOrDimsT]:
+        self, dim: DimOrDimsT | None, reduce_to_dim: DimOrDimsT | None
+    ) -> DimOrDimsT | None:
         if dim is not None and reduce_to_dim is not None:
             raise ValueError(
                 "Only one of 'dim' and 'reduce_to_dim' may be supplied, not both."
@@ -70,9 +70,9 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
     @alias_dims(["dim", "reduce_to_dim"])
     def count(
         self,
-        dim: Optional[DimOrDimsT] = None,
+        dim: DimOrDimsT | None = None,
         *,
-        reduce_to_dim: Optional[DimOrDimsT] = None,
+        reduce_to_dim: DimOrDimsT | None = None,
         keep_attrs: bool = True,
         **kwargs,
     ) -> xr.DataArray:
@@ -110,13 +110,13 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
     @alias_dims(["dim", "reduce_to_dim", "skipna_evaluation_dims"])
     def sum(
         self,
-        dim: Optional[DimOrDimsT] = None,
+        dim: DimOrDimsT | None = None,
         *,
-        reduce_to_dim: Optional[DimOrDimsT] = None,
-        skipna: Optional[bool] = None,
-        skipna_evaluation_dims: Optional[DimOrDimsT] = None,
+        reduce_to_dim: DimOrDimsT | None = None,
+        skipna: bool | None = None,
+        skipna_evaluation_dims: DimOrDimsT | None = None,
         keep_attrs: bool = True,
-        min_count: Optional[int] = None,
+        min_count: int | None = None,
     ) -> xr.DataArray:
         """Reduce this DataArray's data by applying `sum` along some dimension(s).
 
@@ -195,7 +195,7 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
         )
 
     @alias_dims(["dim"])
-    def fill_all_na(self, dim: Union[Iterable[Hashable], str], value=0) -> xr.DataArray:
+    def fill_all_na(self, dim: Iterable[Hashable] | str, value=0) -> xr.DataArray:
         """Fill NA values only where all values along the specified dimension(s) are NA.
 
         Example: having a data array with dimensions ``time`` and ``position``,
@@ -224,7 +224,7 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
 class DatasetAggregationAccessor(BaseDatasetAccessor):
     @staticmethod
     def _apply_fill_all_na(
-        da: xr.DataArray, dim: Union[Iterable[Hashable], str], value
+        da: xr.DataArray, dim: Iterable[Hashable] | str, value
     ) -> xr.DataArray:
         if isinstance(dim, str):
             dim = [dim]
@@ -265,8 +265,8 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         )
 
     def _reduce_dim(
-        self, dim: Optional[DimOrDimsT], reduce_to_dim: Optional[DimOrDimsT]
-    ) -> Optional[Iterable[Hashable]]:
+        self, dim: DimOrDimsT | None, reduce_to_dim: DimOrDimsT | None
+    ) -> Iterable[Hashable] | None:
         if dim is not None and reduce_to_dim is not None:
             raise ValueError(
                 "Only one of 'dim' and 'reduce_to_dim' may be supplied, not both."
@@ -292,9 +292,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
     @alias_dims(["dim", "reduce_to_dim"], additional_allowed_values=["entity"])
     def count(
         self,
-        dim: Optional[DimOrDimsT] = None,
+        dim: DimOrDimsT | None = None,
         *,
-        reduce_to_dim: Optional[DimOrDimsT] = None,
+        reduce_to_dim: DimOrDimsT | None = None,
         keep_attrs: bool = True,
         **kwargs,
     ) -> DatasetOrDataArray:
@@ -350,13 +350,13 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
     @alias_dims(["dim", "reduce_to_dim"], additional_allowed_values=["entity"])
     def sum(
         self,
-        dim: Optional[DimOrDimsT] = None,
+        dim: DimOrDimsT | None = None,
         *,
-        reduce_to_dim: Optional[DimOrDimsT] = None,
-        skipna: Optional[bool] = None,
-        skipna_evaluation_dims: Optional[DimOrDimsT] = None,
+        reduce_to_dim: DimOrDimsT | None = None,
+        skipna: bool | None = None,
+        skipna_evaluation_dims: DimOrDimsT | None = None,
         keep_attrs: bool = True,
-        min_count: Optional[int] = None,
+        min_count: int | None = None,
     ) -> DatasetOrDataArray:
         """Reduce this Dataset's data by applying `sum` along some dimension(s).
 
@@ -459,9 +459,9 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         *,
         basket: str,
         basket_contents: Sequence[str],
-        skipna: Optional[bool] = None,
-        skipna_evaluation_dims: Optional[DimOrDimsT] = None,
-        min_count: Optional[int] = None,
+        skipna: bool | None = None,
+        skipna_evaluation_dims: DimOrDimsT | None = None,
+        min_count: int | None = None,
     ) -> xr.DataArray:
         """The sum of gas basket contents converted using the global warming potential
         of the gas basket.
@@ -521,10 +521,10 @@ class DatasetAggregationAccessor(BaseDatasetAccessor):
         *,
         basket: str,
         basket_contents: Sequence[str],
-        sel: Optional[Mapping[Hashable, Sequence]] = None,
-        skipna: Optional[bool] = None,
-        skipna_evaluation_dims: Optional[DimOrDimsT] = None,
-        min_count: Optional[int] = None,
+        sel: Mapping[Hashable, Sequence] | None = None,
+        skipna: bool | None = None,
+        skipna_evaluation_dims: DimOrDimsT | None = None,
+        min_count: int | None = None,
     ) -> xr.DataArray:
         """Fill NA values in a gas basket using the sum of its contents.
 

--- a/primap2/_alias_selection.py
+++ b/primap2/_alias_selection.py
@@ -86,7 +86,7 @@ def alias(
 
 def alias_dims(
     args_to_alias: typing.Iterable[str],
-    wraps: typing.Optional[typing.Callable] = None,
+    wraps: typing.Callable | None = None,
     additional_allowed_values: typing.Iterable[str] = (),
 ) -> typing.Callable[[FunctionT], FunctionT]:
     """Method decorator to automatically translate dimension aliases in parameters.

--- a/primap2/_data_format.py
+++ b/primap2/_data_format.py
@@ -2,7 +2,7 @@ import contextlib
 import datetime
 import pathlib
 from collections.abc import Hashable, Iterable, Mapping
-from typing import IO, Optional, Union
+from typing import IO
 
 import pandas as pd
 import pint
@@ -14,12 +14,12 @@ from ._units import ureg
 
 
 def open_dataset(
-    filename_or_obj: Union[str, pathlib.Path, IO],
-    group: Optional[str] = None,
-    chunks: Optional[Union[int, dict]] = None,
-    cache: Optional[bool] = None,
-    drop_variables: Optional[Union[str, Iterable]] = None,
-    backend_kwargs: Optional[dict] = None,
+    filename_or_obj: str | pathlib.Path | IO,
+    group: str | None = None,
+    chunks: int | dict | None = None,
+    cache: bool | None = None,
+    drop_variables: str | Iterable | None = None,
+    backend_kwargs: dict | None = None,
 ) -> xr.Dataset:
     """Open and decode a dataset from a file or file-like object.
 
@@ -201,11 +201,11 @@ class DatasetDataFormatAccessor(_accessor_base.BaseDatasetAccessor):
 
     def to_netcdf(
         self,
-        path: Union[pathlib.Path, str],
+        path: pathlib.Path | str,
         mode: str = "w",
-        group: Optional[str] = None,
-        encoding: Union[Mapping, None] = None,
-    ) -> Union[bytes, None]:
+        group: str | None = None,
+        encoding: Mapping | None = None,
+    ) -> bytes | None:
         """Write dataset contents to a netCDF file.
 
         Parameters

--- a/primap2/_downscale.py
+++ b/primap2/_downscale.py
@@ -1,5 +1,4 @@
 from collections.abc import Hashable, Sequence
-from typing import Optional, Union
 
 import xarray as xr
 
@@ -16,8 +15,8 @@ class DataArrayDownscalingAccessor(BaseDataArrayAccessor):
         basket: Hashable,
         basket_contents: Sequence[Hashable],
         check_consistency: bool = True,
-        sel: Optional[dict[Hashable, Sequence]] = None,
-        skipna_evaluation_dims: Union[None, Sequence[Hashable]] = None,
+        sel: dict[Hashable, Sequence] | None = None,
+        skipna_evaluation_dims: None | Sequence[Hashable] = None,
         skipna: bool = True,
         tolerance: float = 0.01,
     ) -> xr.DataArray:
@@ -125,8 +124,8 @@ class DatasetDownscalingAccessor(BaseDatasetAccessor):
         basket: Hashable,
         basket_contents: Sequence[Hashable],
         check_consistency: bool = True,
-        sel: Optional[dict[Hashable, Sequence]] = None,
-        skipna_evaluation_dims: Optional[Sequence[Hashable]] = None,
+        sel: dict[Hashable, Sequence] | None = None,
+        skipna_evaluation_dims: Sequence[Hashable] | None = None,
         skipna: bool = True,
         tolerance: float = 0.01,
     ) -> xr.Dataset:
@@ -237,8 +236,8 @@ class DatasetDownscalingAccessor(BaseDatasetAccessor):
         basket: Hashable,
         basket_contents: Sequence[Hashable],
         check_consistency: bool = True,
-        sel: Optional[dict[Hashable, Sequence]] = None,
-        skipna_evaluation_dims: Optional[Sequence[Hashable]] = None,
+        sel: dict[Hashable, Sequence] | None = None,
+        skipna_evaluation_dims: Sequence[Hashable] | None = None,
         skipna: bool = True,
         tolerance: float = 0.01,
     ) -> xr.Dataset:

--- a/primap2/_merge.py
+++ b/primap2/_merge.py
@@ -1,7 +1,6 @@
 """Merge arrays and datasets with optional tolerances."""
 
 import contextlib
-import typing
 
 import numpy as np
 import xarray as xr
@@ -104,7 +103,7 @@ def generate_log_message(da_error: xr.DataArray, tolerance: float) -> str:
 
 
 def ensure_compatible_coords_dims(
-    a: typing.Union[xr.Dataset, xr.DataArray], b: typing.Union[xr.Dataset, xr.DataArray]
+    a: xr.Dataset | xr.DataArray, b: xr.Dataset | xr.DataArray
 ):
     """Check if coordinates and dimensions of both Datasets or DataArrays agree,
     raise exception otherwise."""

--- a/primap2/_overview.py
+++ b/primap2/_overview.py
@@ -10,9 +10,7 @@ from ._alias_selection import alias_dims
 
 
 class DataArrayOverviewAccessor(_accessor_base.BaseDataArrayAccessor):
-    def to_df(
-        self, name: typing.Optional[str] = None
-    ) -> typing.Union[pd.DataFrame, pd.Series]:
+    def to_df(self, name: str | None = None) -> pd.DataFrame | pd.Series:
         """Convert this array into an unstacked (i.e. non-tidy) pandas.DataFrame.
 
         Converting to an unstacked pandas.DataFrame is most useful for two-dimensional
@@ -41,7 +39,7 @@ class DataArrayOverviewAccessor(_accessor_base.BaseDataArrayAccessor):
             return pandas_obj
 
     @alias_dims(["dims"])
-    def coverage(self, *dims: typing.Hashable) -> typing.Union[pd.DataFrame, pd.Series]:
+    def coverage(self, *dims: typing.Hashable) -> pd.DataFrame | pd.Series:
         """Summarize how many data points exist for a dimension combination.
 
         For each combinations of values in the given dimensions, count the number of
@@ -83,7 +81,7 @@ class DataArrayOverviewAccessor(_accessor_base.BaseDataArrayAccessor):
 class DatasetOverviewAccessor(_accessor_base.BaseDatasetAccessor):
     def to_df(
         self,
-        name: typing.Optional[str] = None,
+        name: str | None = None,
     ) -> pd.DataFrame:
         """Convert this dataset into a pandas.DataFrame.
 
@@ -105,7 +103,7 @@ class DatasetOverviewAccessor(_accessor_base.BaseDatasetAccessor):
         return df
 
     @alias_dims(["dims"], additional_allowed_values=["entity"])
-    def coverage(self, *dims: typing.Hashable) -> typing.Union[pd.DataFrame, pd.Series]:
+    def coverage(self, *dims: typing.Hashable) -> pd.DataFrame | pd.Series:
         """Summarize how many data points exist for a dimension combination.
 
         For each combinations of values in the given dimensions, count the number of

--- a/primap2/_setters.py
+++ b/primap2/_setters.py
@@ -26,9 +26,9 @@ class DataArraySettersAccessor(_accessor_base.BaseDataArrayAccessor):
         self,
         dim: typing.Hashable,
         key: typing.Any,
-        value: typing.Union[xr.DataArray, np.ndarray],
+        value: xr.DataArray | np.ndarray,
         *,
-        value_dims: typing.Optional[list[typing.Hashable]] = None,
+        value_dims: list[typing.Hashable] | None = None,
         existing: str = "fillna_empty",
         new: str = "extend",
     ) -> xr.DataArray:

--- a/primap2/_units.py
+++ b/primap2/_units.py
@@ -3,8 +3,6 @@
 Portions of this file are copied from pint_xarray and are
 Copyright 2020, pint-xarray developers."""
 
-from typing import Optional, Union
-
 import pint
 import pint_xarray
 import xarray as xr
@@ -90,9 +88,7 @@ class DataArrayUnitAccessor(_accessor_base.BaseDataArrayAccessor):
         """
         return self._da.pint.dequantify()
 
-    def convert_to_gwp(
-        self, gwp_context: str, units: Union[str, pint.Unit]
-    ) -> xr.DataArray:
+    def convert_to_gwp(self, gwp_context: str, units: str | pint.Unit) -> xr.DataArray:
         """Convert to a global warming potential
 
         Parameters
@@ -165,7 +161,7 @@ class DataArrayUnitAccessor(_accessor_base.BaseDataArrayAccessor):
         return ureg.context(self._da.attrs["gwp_context"])
 
     def convert_to_mass(
-        self, gwp_context: Optional[str] = None, entity: Optional[str] = None
+        self, gwp_context: str | None = None, entity: str | None = None
     ) -> xr.DataArray:
         """Convert a global warming potential of a greenhouse gas to a mass.
 

--- a/primap2/pm2io/_GHG_inventory_reading.py
+++ b/primap2/pm2io/_GHG_inventory_reading.py
@@ -7,7 +7,6 @@ they are added during the process of reading an preparing data for the PRIMAP-hi
 update. Testing will be added in the future."""
 
 import re
-from typing import Optional, Union
 
 import pandas as pd
 
@@ -15,12 +14,12 @@ import pandas as pd
 def nir_add_unit_information(
     df_nir: pd.DataFrame,
     *,
-    unit_row: Union[str, int],
-    entity_row: Optional[Union[str, int]] = None,
+    unit_row: str | int,
+    entity_row: str | int | None = None,
     regexp_entity: str,
-    regexp_unit: Optional[str] = None,
-    manual_repl_unit: Optional[dict[str, str]] = None,
-    manual_repl_entity: Optional[dict[str, str]] = None,
+    regexp_unit: str | None = None,
+    manual_repl_unit: dict[str, str] | None = None,
+    manual_repl_entity: dict[str, str] | None = None,
     default_unit: str,
 ) -> pd.DataFrame:
     """Add unit information to a National Inventory Report (NIR) style DataFrame.
@@ -135,7 +134,7 @@ def nir_add_unit_information(
 
 
 def nir_convert_df_to_long(
-    df_nir: pd.DataFrame, year: int, header_long: Optional[list[str]] = None
+    df_nir: pd.DataFrame, year: int, header_long: list[str] | None = None
 ) -> pd.DataFrame:
     """Convert an entity-wide NIR table for a single year to a long format
     DataFrame.

--- a/primap2/pm2io/_data_reading.py
+++ b/primap2/pm2io/_data_reading.py
@@ -1,9 +1,9 @@
 import datetime
 import itertools
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import IO, Any, Callable, Union
+from typing import IO, Any
 
 import numpy as np
 import pandas as pd
@@ -35,16 +35,16 @@ def convert_long_dataframe_if(
     data_long: pd.DataFrame,
     *,
     coords_cols: dict[str, str],
-    add_coords_cols: Union[None, dict[str, list[str]]] = None,
-    coords_defaults: Union[None, dict[str, Any]] = None,
+    add_coords_cols: None | dict[str, list[str]] = None,
+    coords_defaults: None | dict[str, Any] = None,
     coords_terminologies: dict[str, str],
-    coords_value_mapping: Union[None, dict[str, Any]] = None,
-    coords_value_filling: Union[None, dict[str, dict[str, dict]]] = None,
-    filter_keep: Union[None, dict[str, dict[str, Any]]] = None,
-    filter_remove: Union[None, dict[str, dict[str, Any]]] = None,
-    meta_data: Union[None, dict[str, Any]] = None,
+    coords_value_mapping: None | dict[str, Any] = None,
+    coords_value_filling: None | dict[str, dict[str, dict]] = None,
+    filter_keep: None | dict[str, dict[str, Any]] = None,
+    filter_remove: None | dict[str, dict[str, Any]] = None,
+    meta_data: None | dict[str, Any] = None,
     time_format: str = "%Y-%m-%d",
-    convert_str: Union[bool, dict[str, float]] = True,
+    convert_str: bool | dict[str, float] = True,
     copy_df: bool = True,
 ) -> pd.DataFrame:
     """convert a DataFrame in long (tidy) format into the PRIMAP2 interchange format.
@@ -258,19 +258,19 @@ data_format_details.html#dataset-attributes>`_.
 
 
 def read_long_csv_file_if(
-    filepath_or_buffer: Union[str, Path, IO],
+    filepath_or_buffer: str | Path | IO,
     *,
     coords_cols: dict[str, str],
-    add_coords_cols: Union[None, dict[str, list[str]]] = None,
-    coords_defaults: Union[None, dict[str, Any]] = None,
+    add_coords_cols: None | dict[str, list[str]] = None,
+    coords_defaults: None | dict[str, Any] = None,
     coords_terminologies: dict[str, str],
-    coords_value_mapping: Union[None, dict[str, Any]] = None,
-    coords_value_filling: Union[None, dict[str, dict[str, dict]]] = None,
-    filter_keep: Union[None, dict[str, dict[str, Any]]] = None,
-    filter_remove: Union[None, dict[str, dict[str, Any]]] = None,
-    meta_data: Union[None, dict[str, Any]] = None,
+    coords_value_mapping: None | dict[str, Any] = None,
+    coords_value_filling: None | dict[str, dict[str, dict]] = None,
+    filter_keep: None | dict[str, dict[str, Any]] = None,
+    filter_remove: None | dict[str, dict[str, Any]] = None,
+    meta_data: None | dict[str, Any] = None,
     time_format: str = "%Y-%m-%d",
-    convert_str: Union[bool, dict[str, float]] = True,
+    convert_str: bool | dict[str, float] = True,
 ) -> pd.DataFrame:
     """Read a CSV file in long (tidy) format into the PRIMAP2 interchange format.
 
@@ -453,17 +453,17 @@ def convert_wide_dataframe_if(
     data_wide: pd.DataFrame,
     *,
     coords_cols: dict[str, str],
-    add_coords_cols: Union[None, dict[str, list[str]]] = None,
-    coords_defaults: Union[None, dict[str, Any]] = None,
+    add_coords_cols: None | dict[str, list[str]] = None,
+    coords_defaults: None | dict[str, Any] = None,
     coords_terminologies: dict[str, str],
-    coords_value_mapping: Union[None, dict[str, Any]] = None,
-    coords_value_filling: Union[None, dict[str, dict[str, dict]]] = None,
-    filter_keep: Union[None, dict[str, dict[str, Any]]] = None,
-    filter_remove: Union[None, dict[str, dict[str, Any]]] = None,
-    meta_data: Union[None, dict[str, Any]] = None,
+    coords_value_mapping: None | dict[str, Any] = None,
+    coords_value_filling: None | dict[str, dict[str, dict]] = None,
+    filter_keep: None | dict[str, dict[str, Any]] = None,
+    filter_remove: None | dict[str, dict[str, Any]] = None,
+    meta_data: None | dict[str, Any] = None,
     time_format: str = "%Y",
-    time_cols: Union[None, list] = None,
-    convert_str: Union[bool, dict[str, float]] = True,
+    time_cols: None | list = None,
+    convert_str: bool | dict[str, float] = True,
     copy_df: bool = False,
 ) -> pd.DataFrame:
     """
@@ -691,19 +691,19 @@ data_format_details.html#dataset-attributes>`_.
 
 
 def read_wide_csv_file_if(
-    filepath_or_buffer: Union[str, Path, IO],
+    filepath_or_buffer: str | Path | IO,
     *,
     coords_cols: dict[str, str],
-    add_coords_cols: Union[None, dict[str, list[str]]] = None,
-    coords_defaults: Union[None, dict[str, Any]] = None,
+    add_coords_cols: None | dict[str, list[str]] = None,
+    coords_defaults: None | dict[str, Any] = None,
     coords_terminologies: dict[str, str],
-    coords_value_mapping: Union[None, dict[str, Any]] = None,
-    coords_value_filling: Union[None, dict[str, dict[str, dict]]] = None,
-    filter_keep: Union[None, dict[str, dict[str, Any]]] = None,
-    filter_remove: Union[None, dict[str, dict[str, Any]]] = None,
-    meta_data: Union[None, dict[str, Any]] = None,
+    coords_value_mapping: None | dict[str, Any] = None,
+    coords_value_filling: None | dict[str, dict[str, dict]] = None,
+    filter_keep: None | dict[str, dict[str, Any]] = None,
+    filter_remove: None | dict[str, dict[str, Any]] = None,
+    meta_data: None | dict[str, Any] = None,
     time_format: str = "%Y",
-    convert_str: Union[bool, dict[str, float]] = True,
+    convert_str: bool | dict[str, float] = True,
 ) -> pd.DataFrame:
     """Read a CSV file in wide format into the PRIMAP2 interchange format.
 
@@ -879,7 +879,7 @@ def interchange_format_attrs_dict(
     xr_attrs: dict,
     time_format: str,
     dimensions,
-    additional_coordinates: Union[None, dict] = None,
+    additional_coordinates: None | dict = None,
 ) -> dict:
     metadata = {
         "attrs": xr_attrs,
@@ -985,7 +985,7 @@ def matches_time_format(value: str, time_format: str) -> bool:
 def read_wide_csv(
     filepath_or_buffer,
     coords_cols: dict[str, str],
-    add_coords_cols: Union[None, dict[str, list[str]]] = None,
+    add_coords_cols: None | dict[str, list[str]] = None,
     time_format: str = "%Y",
 ) -> tuple[pd.DataFrame, list[str]]:
     data = pd.read_csv(
@@ -1029,7 +1029,7 @@ def read_wide_csv(
 def read_long_csv(
     filepath_or_buffer,
     coords_cols: dict[str, str],
-    add_coords_cols: Union[None, dict[str, list[str]]] = None,
+    add_coords_cols: None | dict[str, list[str]] = None,
 ) -> pd.DataFrame:
     if "data" not in coords_cols.keys():
         raise ValueError(
@@ -1075,8 +1075,8 @@ def spec_to_query_string(filter_spec: dict[str, Any]) -> str:
 
 def filter_data(
     data: pd.DataFrame,
-    filter_keep: Union[None, dict[str, dict[str, Any]]] = None,
-    filter_remove: Union[None, dict[str, dict[str, Any]]] = None,
+    filter_keep: None | dict[str, dict[str, Any]] = None,
+    filter_remove: None | dict[str, dict[str, Any]] = None,
 ):
     # Filters for keeping data are combined with "or" so that
     # everything matching at least one rule is kept.
@@ -1177,7 +1177,7 @@ def add_dimensions_from_defaults(
 def map_metadata(
     data: pd.DataFrame,
     *,
-    meta_mapping: dict[str, Union[str, Callable, dict]],
+    meta_mapping: dict[str, str | Callable | dict],
     attrs: dict[str, Any],
 ):
     """Map the metadata according to specifications given in meta_mapping.
@@ -1194,7 +1194,7 @@ def map_metadata(
 def map_metadata_unordered(
     data: pd.DataFrame,
     *,
-    meta_mapping: dict[str, Union[str, Callable, dict]],
+    meta_mapping: dict[str, str | Callable | dict],
     attrs: dict[str, Any],
 ):
     """Map the metadata according to specifications given in meta_mapping."""
@@ -1236,7 +1236,9 @@ def map_metadata_unordered(
             if not args:  # simple case: no additional args needed
                 values_to_map = data[column_name].unique()
                 values_mapped = map(func, values_to_map)
-                meta_mapping_df[column_name] = dict(zip(values_to_map, values_mapped))
+                meta_mapping_df[column_name] = dict(
+                    zip(values_to_map, values_mapped, strict=False)
+                )
 
             else:  # need to supply additional arguments
                 # this can't be handled using the replace()-call later since the
@@ -1356,7 +1358,7 @@ def parse_code(code: str) -> float:
 
 def create_str_replacement_dict(
     strs: list[str],
-    user_str_conv: Union[bool, dict[str, float]],
+    user_str_conv: bool | dict[str, float],
 ) -> dict[str, str]:
     """Create a dict for replacement of strings by NaN and 0 based on
     general rules and user defined rules"""
@@ -1390,7 +1392,7 @@ def replace_values(data: pd.DataFrame, columns: list[str], na_repl_dict):
         data[col] = data[col].astype("float64", copy=False, errors="ignore")
 
 
-def preferred_unit(entity: str, units: dict[str, str]) -> Union[str, None]:
+def preferred_unit(entity: str, units: dict[str, str]) -> str | None:
     """Choose the preferred unit for the given entity.
 
     In general, "Gg <substance> / year" will be preferred if it is compatible with the
@@ -1486,8 +1488,8 @@ def preferred_unit(entity: str, units: dict[str, str]) -> Union[str, None]:
 def harmonize_units(
     data: pd.DataFrame,
     *,
-    unit_col: Union[None, str] = None,
-    attrs: Union[None, dict] = None,
+    unit_col: None | str = None,
+    attrs: None | dict = None,
     dimensions: Iterable[str],
 ) -> None:
     """Harmonize the units of the input data.

--- a/primap2/pm2io/_interchange_format.py
+++ b/primap2/pm2io/_interchange_format.py
@@ -2,7 +2,6 @@ import csv
 import itertools
 import re
 from pathlib import Path
-from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -131,7 +130,7 @@ def metadata_for_variable(unit: str, variable: str) -> dict[str, str]:
 
 
 def write_interchange_format(
-    filepath: Union[str, Path], data: pd.DataFrame, attrs: Optional[dict] = None
+    filepath: str | Path, data: pd.DataFrame, attrs: dict | None = None
 ) -> None:
     """Write dataset in interchange format to disk.
 
@@ -175,7 +174,7 @@ def write_interchange_format(
 
 
 def read_interchange_format(
-    filepath: Union[str, Path],
+    filepath: str | Path,
 ) -> pd.DataFrame:
     """Read a dataset in the interchange format from disk into memory.
 
@@ -223,7 +222,7 @@ def read_interchange_format(
 
 def from_interchange_format(
     data: pd.DataFrame,
-    attrs: Optional[dict] = None,
+    attrs: dict | None = None,
     max_array_size: int = 1024 * 1024 * 1024,
 ) -> xr.Dataset:
     """Convert dataset from the interchange format to the standard PRIMAP2 format.
@@ -277,7 +276,9 @@ def from_interchange_format(
                 f"value for {coord}."
             )
 
-        add_coord_mapping_dicts[coord] = dict(zip(dim_values, coord_values))
+        add_coord_mapping_dicts[coord] = dict(
+            zip(dim_values, coord_values, strict=False)
+        )
 
     # drop additional coordinates. make a copy first to not alter input DF
     data_drop = data.drop(columns=attrs["additional_coordinates"].keys(), inplace=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ extend-exclude = [
   "climate_categories/tests/data/*.py"
 ]
 extend-select = [ "W", "I", "UP", "B", "NPY", "RUF" ]
-target-version = "py39"
+target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ extend-exclude = [
   "climate_categories/data/*.py",
   "climate_categories/tests/data/*.py"
 ]
-extend-select = [ "W", "I", "UP", "B", "NPY", "RUF" ]
+lint.extend-select = [ "W", "I", "UP", "B", "NPY", "RUF" ]
 target-version = "py310"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
 license = Apache Software License 2.0
@@ -28,7 +27,7 @@ packages =
     primap2.pm2io
     primap2.tests
     primap2.tests.data
-python_requires = >=3.9
+python_requires = >=3.10
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39, py310, py311
+envlist = py310, py311
 
 [testenv]
 deps =


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

Numpy will stop supporting Python 3.9 on April 5th, so let's stop writing code for Python 3.9 now.
