### PR TITLE
Tighten dependencies on python versions

### DIFF
--- a/.check_python_version.py
+++ b/.check_python_version.py
@@ -1,14 +1,23 @@
 """Check if the used version of Python is good enough for us."""
 
-# ruff: noqa
+import itertools
 import sys
 
-MIN_VERSION = (3, 9)
+SUPPORTED_MAJOR_VERSIONS = (3,)
+SUPPORTED_MINOR_VERSIONS = (10, 11)
 
-if sys.version_info < (3, 9):
-    min_version_human_readable = ".".join(str(x) for x in MIN_VERSION)
+if (
+    sys.version_info.major not in SUPPORTED_MAJOR_VERSIONS
+    or sys.version_info.minor not in SUPPORTED_MINOR_VERSIONS
+):
+    supported_versions = itertools.product(
+        SUPPORTED_MAJOR_VERSIONS, SUPPORTED_MINOR_VERSIONS
+    )
+    supported_versions_human_readable = ", ".join(
+        ".".join(str(x) for x in version) for version in supported_versions
+    )
     print(
         f"Python version {sys.version_info} not supported, please install Python"
-        f" version {min_version_human_readable} or higher"
+        f" in one of the supported versions: {supported_versions_human_readable}."
     )
     sys.exit(1)

--- a/changelog_unreleased/no-python312.rst
+++ b/changelog_unreleased/no-python312.rst
@@ -1,0 +1,1 @@
+* Explicitly required supported python versions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages =
     primap2.pm2io
     primap2.tests
     primap2.tests.data
-python_requires = >=3.10
+python_requires = >=3.10, <3.12
 setup_requires =
     setuptools_scm
 install_requires =


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

Specify minimal and maximal python versions in our python version dependencies.

I guess the `.check_python_version.py` script is not necessary any more (pip rejects this by itself using the configuration in `setup.cfg`), but it has the advantage that it is run in Makefile before anything else when setting up a development environment, so it provides a fast feedback and readable error message. So, I just left it in.

Closes: #206 