### PR TITLE
Support saving and loading processing information

### DIFF
--- a/changelog_unreleased/compose-entity.rst
+++ b/changelog_unreleased/compose-entity.rst
@@ -1,0 +1,2 @@
+* Added support for specifying the entity in priority and strategy selectors.
+* Added support for specifying multiple values in priority and strategy selectors.

--- a/primap2/csg/__init__.py
+++ b/primap2/csg/__init__.py
@@ -5,7 +5,11 @@ source priorities and matching algorithms.
 """
 
 from ._compose import compose
-from ._models import PriorityDefinition, StrategyDefinition
+from ._models import (
+    PriorityDefinition,
+    StrategyDefinition,
+    TimeseriesProcessingDescription,
+)
 from ._strategies.substitution import SubstitutionStrategy
 
 __all__ = [
@@ -13,4 +17,5 @@ __all__ = [
     "PriorityDefinition",
     "StrategyDefinition",
     "SubstitutionStrategy",
+    "TimeseriesProcessingDescription",
 ]

--- a/primap2/csg/_compose.py
+++ b/primap2/csg/_compose.py
@@ -1,6 +1,7 @@
 """Compose a harmonized dataset from multiple input datasets."""
 
 import math
+import typing
 from collections.abc import Hashable
 
 import numpy as np
@@ -77,52 +78,52 @@ def compose(
         describe the processing steps done for each timeseries.
     """
     result_das = {}
+    input_data = input_data.pr.dequantify()
 
     if progress_bar is None:
         entity_iterator = input_data
     else:
         entity_iterator = progress_bar(input_data)
+
+    priority_dimensions = priority_definition.priority_dimensions
+    priority_definition.check_dimensions()
+
     for entity in entity_iterator:
         if progress_bar is not None:
-            entity_iterator.set_postfix_str(entity)
-        input_da = input_data[entity].pr.dequantify()
+            entity_iterator.set_postfix_str(str(entity))
+
+        input_da = input_data[entity]
+
         # all dimensions are either time, priority selection dimensions, or need to
         # be iterated over
         group_by_dimensions = tuple(
             dim
             for dim in input_da.dims
-            if dim != "time" and dim not in priority_definition.priority_dimensions
+            if dim != "time" and dim not in priority_dimensions
         )
-        # pre-allocate result arrays which will be filled timeseries-by-timeseries
-        result_dimensions = ["time", *group_by_dimensions]
-        result_das[entity] = xr.DataArray(
-            data=np.nan,
-            dims=result_dimensions,
-            coords={
-                dim: input_da.coords[dim]
-                for dim in input_da.coords
-                if dim not in priority_definition.priority_dimensions
-            },
-            attrs=input_da.attrs,
+
+        (
+            result_das[entity],
+            result_das[f"Processing of {entity}"],
+        ) = preallocate_result_arrays(
+            input_da=input_da,
+            group_by_dimensions=group_by_dimensions,
+            priority_dimensions=priority_dimensions,
         )
-        result_das[f"Processing of {entity}"] = xr.DataArray(
-            data=np.empty(
-                [len(input_da.coords[dim]) for dim in group_by_dimensions], dtype=object
-            ),
-            dims=group_by_dimensions,
-            coords=[input_da.coords[dim] for dim in group_by_dimensions],
-        )
+
         number_of_timeseries = math.prod(
             len(input_da[dim]) for dim in group_by_dimensions
         )
+
         if progress_bar is None:
             pbar = None
         else:
             pbar = progress_bar(total=number_of_timeseries, unit="ts", unit_scale=True)
+
         iterate_next_fixed_dimension(
             input_da=input_da,
-            priority_definition=priority_definition,
-            strategy_definition=strategy_definition,
+            priority_definition=priority_definition.limit("entity", entity),
+            strategy_definition=strategy_definition.limit("entity", entity),
             group_by_dimensions=group_by_dimensions,
             result_da=result_das[entity],
             result_processing_da=result_das[f"Processing of {entity}"],
@@ -134,12 +135,39 @@ def compose(
     return xr.Dataset(result_das).pr.quantify()
 
 
+def preallocate_result_arrays(
+    *,
+    group_by_dimensions: typing.Iterable[Hashable],
+    input_da: xr.DataArray,
+    priority_dimensions: typing.Iterable[Hashable],
+) -> tuple[xr.DataArray, xr.DataArray]:
+    """Create empty arrays in the right shape to hold the result."""
+    result_da = xr.DataArray(
+        data=np.nan,
+        dims=["time", *group_by_dimensions],
+        coords={
+            dim: input_da.coords[dim]
+            for dim in input_da.coords
+            if dim not in priority_dimensions
+        },
+        attrs=input_da.attrs,
+    )
+    processing_result_da = xr.DataArray(
+        data=np.empty(
+            [len(input_da.coords[dim]) for dim in group_by_dimensions], dtype=object
+        ),
+        dims=group_by_dimensions,
+        coords=[input_da.coords[dim] for dim in group_by_dimensions],
+    )
+    return result_da, processing_result_da
+
+
 def priority_coordinates_repr(
-    *, fill_ts: xr.DataArray, priority_dimensions: list[str]
+    *, fill_ts: xr.DataArray, priority_dimensions: list[Hashable]
 ) -> str:
     """Reduce the priority coordinates to a short string representation."""
     priority_coordinates: dict[str, str] = {
-        k: fill_ts[k].item() for k in priority_dimensions
+        str(k): fill_ts[k].item() for k in priority_dimensions
     }
     if len(priority_coordinates) == 1:
         # only one priority dimension, just output the value because it is clear what is

--- a/primap2/csg/_models.py
+++ b/primap2/csg/_models.py
@@ -67,7 +67,7 @@ class PriorityDefinition:
                     )
 
 
-@define
+@define(frozen=True)
 class ProcessingStepDescription:
     """Structured description of a processing step done on a timeseries."""
 
@@ -79,7 +79,7 @@ class ProcessingStepDescription:
         return f"Using strategy={self.strategy} for times={self.time}: {self.processing_description}"
 
 
-@define
+@define(frozen=True)
 class TimeseriesProcessingDescription:
     """Structured description of all processing steps done on a timeseries."""
 

--- a/primap2/csg/_models.py
+++ b/primap2/csg/_models.py
@@ -53,7 +53,7 @@ class PriorityDefinition:
         )
 
     def check_dimensions(self):
-        """Raise an error if not all priorities specify all selection dimensions."""
+        """Raise an error if not all priorities specify all priority dimensions."""
         for sel in self.priorities:
             for dim in self.priority_dimensions:
                 if dim not in sel:

--- a/primap2/csg/_models.py
+++ b/primap2/csg/_models.py
@@ -55,7 +55,7 @@ class PriorityDefinition:
     def check_dimensions(self):
         """Raise an error if not all priorities specify all selection dimensions."""
         for sel in self.priorities:
-            for dim in self.selection_dimensions:
+            for dim in self.priority_dimensions:
                 if dim not in sel:
                     raise ValueError(
                         f"In priority={sel}: missing priority dimension={dim}"

--- a/primap2/csg/_models.py
+++ b/primap2/csg/_models.py
@@ -8,7 +8,7 @@ import xarray as xr
 from attr import define
 
 
-@define
+@define(frozen=True)
 class PriorityDefinition:
     """
     Defines source priorities for composing a full dataset or a single timeseries.
@@ -24,14 +24,15 @@ class PriorityDefinition:
         selection has to specify all priority_dimensions, but may specify additional
         dimensions (fixed dimensions) to limit the selection to specific cases.
         Examples:
-        [{"area (ISO3)": "COL", "source": "A"}, {"source": "B"}]
-        would select source "A"as highest priority source and source "B" as
-        lower-priority source for Columbia, but source "B" as highest-priority (and
-        only) source for all other countries.
+        [{"area (ISO3)": ["MEX", "COL"], "source": "A"}, {"source": "B"}]
+        would select source "A" as highest-priority source and source "B" as
+        lower-priority source for Columbia and Mexico, but source "B" as
+        highest-priority (and only) source for all other
+        countries.
     """
 
     priority_dimensions: list[Hashable]
-    priorities: list[dict[Hashable, str]]
+    priorities: list[dict[Hashable, str | list[str]]]
 
     def limit(self, dim: Hashable, value: str) -> "PriorityDefinition":
         """Remove one fixed dimension by limiting to a single value.
@@ -42,12 +43,28 @@ class PriorityDefinition:
         for sel in self.priorities:
             if dim not in sel:
                 new_priorities.append(sel)
-            elif sel[dim] == value:
+            elif (isinstance(sel[dim], str) and sel[dim] == value) or (
+                value in sel[dim]
+            ):
                 # filter out the matching value
                 new_priorities.append({k: v for k, v in sel.items() if k != dim})
         return PriorityDefinition(
             priority_dimensions=self.priority_dimensions, priorities=new_priorities
         )
+
+    def check_dimensions(self):
+        """Raise an error if not all priorities specify all selection dimensions."""
+        for sel in self.priorities:
+            for dim in self.selection_dimensions:
+                if dim not in sel:
+                    raise ValueError(
+                        f"In priority={sel}: missing priority dimension={dim}"
+                    )
+                if not isinstance(sel[dim], str):
+                    raise ValueError(
+                        f"In priority={sel}: specified multiple values for priority "
+                        f"dimension={dim}, values={sel[dim]}"
+                    )
 
 
 @define
@@ -72,7 +89,7 @@ class TimeseriesProcessingDescription:
         return "\n".join(str(step) for step in self.steps)
 
 
-class FillingStrategyModel(typing.Protocol):
+class FillingStrategyModel(typing.Protocol, Hashable):
     """
     Fill missing data in a timeseries using another timeseries.
     """
@@ -113,7 +130,7 @@ class FillingStrategyModel(typing.Protocol):
         ...
 
 
-@define
+@define(frozen=True)
 class StrategyDefinition:
     """
     Defines filling strategies for a single timeseries.
@@ -158,7 +175,14 @@ class StrategyDefinition:
         *, selector: dict[Hashable, str | list[str]], fill_ts: xr.DataArray
     ) -> bool:
         """Check if a selected timeseries for filling matches the selector."""
-        return all(fill_ts.coords[k] == v for (k, v) in selector.items())
+        for k, v in selector.items():
+            if isinstance(v, str):
+                if not fill_ts.coords[k] == v:
+                    return False
+            else:
+                if fill_ts.coords[k] not in v:
+                    return False
+        return True
 
     @staticmethod
     def match_single_dim(
@@ -167,6 +191,6 @@ class StrategyDefinition:
         """Check if a literal value in one dimension can match the selector."""
         if dim not in selector.keys():
             return True
-        if isinstance(selector[dim], list):
-            return value in selector[dim]
-        return value == selector[dim]
+        if isinstance(selector[dim], str):
+            return value == selector[dim]
+        return value in selector[dim]

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -152,12 +152,13 @@ def test_compose_trivial():
 
     # generally, prefer source RAND2020, scenario lowpop,
     # then use source RAND2021, scenario highpop.
-    # however, for Columbia, use source RAND2020, scenario highpop as highest priority
+    # however, for Columbia CH4, use source RAND2020, scenario highpop as highest priority
     # (this combination is not used at all otherwise).
     priority_definition = primap2.csg.PriorityDefinition(
         priority_dimensions=["source", "scenario (FAOSTAT)"],
         priorities=[
             {
+                "entity": "CH4",
                 "area (ISO3)": "COL",
                 "source": "RAND2020",
                 "scenario (FAOSTAT)": "highpop",
@@ -183,9 +184,9 @@ def test_compose_trivial():
     )
     assert "CO2" in result.keys()
     assert "Processing of CO2" in result.keys()
-    result_col = result["CO2"].loc[{"area (ISO3)": "COL"}]
+    result_col = result["CH4"].loc[{"area (ISO3)": "COL"}]
     expected_col = (
-        input_data["CO2"]
+        input_data["CH4"]
         .loc[
             {
                 "area (ISO3)": "COL",
@@ -198,7 +199,7 @@ def test_compose_trivial():
     )
     xr.testing.assert_identical(result_col, expected_col)
     result_col_proc = (
-        result["Processing of CO2"].loc[{"area (ISO3)": "COL"}].values.flat[0]
+        result["Processing of CH4"].loc[{"area (ISO3)": "COL"}].values.flat[0]
     )
     assert len(result_col_proc.steps) == 1
     assert result_col_proc.steps[0].time == "all"
@@ -209,9 +210,9 @@ def test_compose_trivial():
         in result_col_proc.steps[0].processing_description
     )
 
-    result_arg = result["CO2"].loc[{"area (ISO3)": "ARG"}]
+    result_arg = result["CH4"].loc[{"area (ISO3)": "ARG"}]
     expected_arg = (
-        input_data["CO2"]
+        input_data["CH4"]
         .loc[
             {
                 "area (ISO3)": "ARG",
@@ -224,7 +225,7 @@ def test_compose_trivial():
     )
     xr.testing.assert_identical(result_arg, expected_arg)
     result_arg_proc = (
-        result["Processing of CO2"].loc[{"area (ISO3)": "ARG"}].values.flat[0]
+        result["Processing of CH4"].loc[{"area (ISO3)": "ARG"}].values.flat[0]
     )
     assert len(result_arg_proc.steps) == 1
     assert result_arg_proc.steps[0].time == "all"
@@ -233,6 +234,32 @@ def test_compose_trivial():
     assert (
         "'scenario (FAOSTAT)': 'lowpop'"
         in result_arg_proc.steps[0].processing_description
+    )
+
+    result_col_co2 = result["CO2"].loc[{"area (ISO3)": "COL"}]
+    expected_col_co2 = (
+        input_data["CO2"]
+        .loc[
+            {
+                "area (ISO3)": "COL",
+                "source": "RAND2020",
+                "scenario (FAOSTAT)": "lowpop",
+            }
+        ]
+        .drop("scenario (FAOSTAT)")
+        .drop("source")
+    )
+    xr.testing.assert_identical(result_col_co2, expected_col_co2)
+    result_col_co2_proc = (
+        result["Processing of CO2"].loc[{"area (ISO3)": "COL"}].values.flat[0]
+    )
+    assert len(result_col_co2_proc.steps) == 1
+    assert result_col_co2_proc.steps[0].time == "all"
+    assert result_col_co2_proc.steps[0].strategy == "initial"
+    assert "'source': 'RAND2020'" in result_col_co2_proc.steps[0].processing_description
+    assert (
+        "'scenario (FAOSTAT)': 'lowpop'"
+        in result_col_co2_proc.steps[0].processing_description
     )
 
 

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -72,6 +72,9 @@ def test_selector_match():
     assert not primap2.csg.StrategyDefinition.match(
         selector={"source": "A", "category": "1"}, fill_ts=da
     )
+    assert not primap2.csg.StrategyDefinition.match(
+        selector={"source": "A", "category": ["1", "2"]}, fill_ts=da
+    )
 
 
 def test_selector_match_single_dim():

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -225,8 +225,8 @@ def test_compose_trivial():
                 "scenario (FAOSTAT)": "highpop",
             }
         ]
-        .drop("scenario (FAOSTAT)")
-        .drop("source")
+        .drop_vars("scenario (FAOSTAT)")
+        .drop_vars("source")
     )
     xr.testing.assert_identical(result_col, expected_col)
     result_col_proc = (
@@ -251,8 +251,8 @@ def test_compose_trivial():
                 "scenario (FAOSTAT)": "lowpop",
             }
         ]
-        .drop("scenario (FAOSTAT)")
-        .drop("source")
+        .drop_vars("scenario (FAOSTAT)")
+        .drop_vars("source")
     )
     xr.testing.assert_identical(result_arg, expected_arg)
     result_arg_proc = (
@@ -277,8 +277,8 @@ def test_compose_trivial():
                 "scenario (FAOSTAT)": "lowpop",
             }
         ]
-        .drop("scenario (FAOSTAT)")
-        .drop("source")
+        .drop_vars("scenario (FAOSTAT)")
+        .drop_vars("source")
     )
     xr.testing.assert_identical(result_col_co2, expected_col_co2)
     result_col_co2_proc = (

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -66,6 +66,9 @@ def test_selector_match():
     assert primap2.csg.StrategyDefinition.match(
         selector={"source": "A", "category": "1.A"}, fill_ts=da
     )
+    assert primap2.csg.StrategyDefinition.match(
+        selector={"source": "A", "category": ["1.A", "1.B"]}, fill_ts=da
+    )
     assert not primap2.csg.StrategyDefinition.match(
         selector={"source": "A", "category": "1"}, fill_ts=da
     )
@@ -112,6 +115,28 @@ def test_strategy_definition():
                 ({"source": "B", "category": "1.B"}, 3),
             ]
         ).find_strategy(da)
+
+
+def test_priority_limit():
+    pd = primap2.csg.PriorityDefinition(
+        selection_dimensions=["a", "b"],
+        priorities=[
+            {"a": "1", "b": "2", "c": "3", "d": ["4", "5"]},
+            {"a": "2", "b": "3"},
+        ],
+    )
+    assert pd.limit("e", "3") == pd
+    assert pd.limit("c", "3").priorities == [
+        {"a": "1", "b": "2", "d": ["4", "5"]},
+        {"a": "2", "b": "3"},
+    ]
+    assert pd.limit("c", "4").priorities == [{"a": "2", "b": "3"}]
+    assert pd.limit("d", "4").priorities == [
+        {"a": "1", "b": "2", "c": "3"},
+        {"a": "2", "b": "3"},
+    ]
+    assert pd.limit("d", "5") == pd.limit("d", "4")
+    assert pd.limit("d", "6").priorities == [{"a": "2", "b": "3"}]
 
 
 def test_compose_trivial():

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -139,6 +139,34 @@ def test_priority_limit():
     assert pd.limit("d", "6").priorities == [{"a": "2", "b": "3"}]
 
 
+def test_priority_check():
+    primap2.csg.PriorityDefinition(
+        selection_dimensions=["a", "b"],
+        priorities=[
+            {"a": "1", "b": "2", "c": "3", "d": ["4", "5"]},
+            {"a": "2", "b": "3"},
+        ],
+    ).check_dimensions()
+
+    with pytest.raises(ValueError):
+        primap2.csg.PriorityDefinition(
+            selection_dimensions=["a", "b"],
+            priorities=[
+                {"a": "1", "b": "2", "c": "3", "d": ["4", "5"]},
+                {"a": "2"},
+            ],
+        ).check_dimensions()
+
+    with pytest.raises(ValueError):
+        primap2.csg.PriorityDefinition(
+            selection_dimensions=["a", "b"],
+            priorities=[
+                {"a": "1", "b": "2", "c": "3", "d": ["4", "5"]},
+                {"a": "2", "b": ["2", "3"]},
+            ],
+        ).check_dimensions()
+
+
 def test_compose_trivial():
     input_data = primap2.tests.examples.opulent_ds()
     input_data = input_data.drop_vars(["population", "SF6 (SARGWP100)"])

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ dev =
     tox
     numpydoc
     ruff
+    ruff-lsp
 datalad =
     datalad
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ dev =
     mypy
     tox
     numpydoc
+    ruff
 datalad =
     datalad
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     strictyaml
     openpyxl
     tqdm
+    msgpack
 
 [options.extras_require]
 test =


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

By serializing processing information as `bytes`, we support saving datasets with processing information to disk as netcdf and loading them from disk.

Supporting this in the interchange format is basically impossible because the processing information doesn't have the `time` dimension, and I figured we don't really care. People who are using the interchange format probably can't handle the processing information anyway.

Points of discussion still open for me @JGuetschow :
* is it actually useful to store / load this as "rich" datatypes (which have e.g. `.time` as numpy arrays and the steps are a list of stp objects, etc), or is a string more useful? The rich datatypes could be useful e.g. if you want to do something more fancy than a string, like an html table or whatever.
* Do we want to *publish* this or is it purely for internal use? If we want to publish, we probably have to invent some other format, the current binary format is proprietary and therefore hard to use for people not using `primap2`.

