### PR TITLE
Properly use variables and entities in definitions and skipping

### DIFF
--- a/primap2/csg/_compose.py
+++ b/primap2/csg/_compose.py
@@ -39,8 +39,8 @@ def compose(
 
     In addition to the harmonized data, also a description of the processing steps
     done for each timeseries is returned in the result dataset, where for each
-    entity, a variable of the form "Processing of $entity" is returned, with the same
-    dimensions as the entity, apart from the time dimension.
+    variable, a variable of the form "Processing of $variable" is returned, with the
+    same dimensions as the variable, apart from the time dimension.
 
     Parameters
     ----------
@@ -59,8 +59,10 @@ def compose(
         e.g., possible to define a different priority for a specific country by listing
         it early (i.e. with high priority) before the more general rules which should
         be applied for all other countries.
-        You can also specify the "entity" in the selection, which will limit the rule
-        to a specific entity (xarray data variable).
+        You can also specify the "entity" or "variable" in the selection, which will
+        limit the rule to a specific entity or variable, respectively. For each
+        DataArray in the input_data Dataset, the variable is its name, the entity is
+        the value of the key `entity` in its attrs.
     strategy_definition
         Defines the filling strategies to be used when filling timeseries with other
         timeseries. Again, the priority is defined by a list of selections and
@@ -69,8 +71,10 @@ def compose(
         define a default strategy which should be used for all timeseries unless
         something else is configured, configure an empty selection as the last
         (rightmost) entry.
-        You can also specify the "entity" in the selection, which will limit the rule
-        to a specific entity (xarray data variable).
+        You can also specify the "entity" or "variable" in the selection, which will
+        limit the rule to a specific entity or variable, respectively. For each
+        DataArray in the input_data Dataset, the variable is its name, the entity is
+        the value of the key `entity` in its attrs.
     progress_bar
         By default, show progress bars using the tqdm package during the
         operation. If None, don't show any progress bars. You can supply a class

--- a/primap2/csg/_compose.py
+++ b/primap2/csg/_compose.py
@@ -85,7 +85,7 @@ def compose(
         result. Dataset with the same entities and dimensions as input_data, but with
         following changes: the data is composed and filled according to the rules,
         the priority dimensions are reduced and not included in the result, and
-        additional variables of the form "Processing of $entity" are added which
+        additional variables of the form "Processing of variable" are added which
         describe the processing steps done for each timeseries.
     """
     result_das = {}

--- a/primap2/csg/_compose.py
+++ b/primap2/csg/_compose.py
@@ -85,7 +85,7 @@ def compose(
         result. Dataset with the same entities and dimensions as input_data, but with
         following changes: the data is composed and filled according to the rules,
         the priority dimensions are reduced and not included in the result, and
-        additional variables of the form "Processing of variable" are added which
+        additional variables of the form "Processing of $variable" are added which
         describe the processing steps done for each timeseries.
     """
     result_das = {}

--- a/primap2/csg/_models.py
+++ b/primap2/csg/_models.py
@@ -103,10 +103,7 @@ class PriorityDefinition:
             # for each possible type of match_value, skip this if it *doesn't* match
             if isinstance(match_value, primap2.Not):
                 not_value = match_value.value
-                if isinstance(not_value, str):
-                    if not_value == value:
-                        continue
-                elif value in not_value:
+                if equal_or_in(value, not_value):
                     continue
             elif isinstance(match_value, str):
                 if match_value != value:

--- a/primap2/csg/_models.py
+++ b/primap2/csg/_models.py
@@ -11,23 +11,27 @@ import primap2
 from primap2._data_format import ProcessingStepDescription
 
 
+def equal_or_in(a, b):
+    """Check if a == b (b str) or a in b (otherwise)."""
+    if isinstance(b, str):
+        return a == b
+    else:
+        return a in b
+
+
 def match_selector(
     *, selector: dict[Hashable, str | list[str]], ts: xr.DataArray
 ) -> bool:
     """Check if a timeseries matches the selector."""
     for k, v in selector.items():
         if k == "entity":
-            if isinstance(v, str):
-                if v != ts.attrs["entity"]:
-                    return False
-            elif ts.attrs["entity"] not in v:
+            if not equal_or_in(ts.attrs["entity"], v):
                 return False
-        else:
-            if isinstance(v, str):
-                if not ts.coords[k] == v:
-                    return False
-            elif ts.coords[k] not in v:
+        elif k == "variable":
+            if not equal_or_in(ts.name, v):
                 return False
+        elif not equal_or_in(ts.coords[k], v):
+            return False
     return True
 
 

--- a/primap2/csg/_models.py
+++ b/primap2/csg/_models.py
@@ -296,13 +296,23 @@ class StrategyDefinition:
             ]
         )
 
+    def check_dimensions(self, ds: xr.Dataset):
+        """Raise an error if the strategy definition uses the wrong dimensions."""
+        applicable_dimensions = set(ds.dims.keys()).union({"entity", "variable"})
+        for sel, _ in self.strategies:
+            for dim in sel:
+                if dim not in applicable_dimensions:
+                    raise ValueError(
+                        f"In selector={sel!r}: {dim=} is not a valid dimension. Valid "
+                        f"dimensions: {applicable_dimensions}."
+                    )
+
     @staticmethod
     def match_single_dim(
         *, selector: dict[Hashable, str | list[str]], dim: Hashable, value: str
     ) -> bool:
         """Check if a literal value in one dimension can match the selector."""
-        if dim not in selector.keys():
+        if dim in selector:
+            return equal_or_in(value, selector[dim])
+        else:
             return True
-        if isinstance(selector[dim], str):
-            return value == selector[dim]
-        return value in selector[dim]

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -485,6 +485,40 @@ def test_compose_skip_entity(opulent_ds):
     assert result["SF6"].isnull().all()
 
 
+def test_compose_variable_entity(opulent_ds):
+    """Test that no strategy is found when specifying variable names for entity"""
+    input_data = opulent_ds[["SF6 (SARGWP100)"]].pr.loc[
+        {
+            "animal": ["cow"],
+            "product": ["milk"],
+            "category": ["0", "1"],
+            "area": ["COL"],
+        }
+    ]
+
+    priority_definition = primap2.csg.PriorityDefinition(
+        priority_dimensions=["source"],
+        priorities=[
+            {"source": "RAND2020"},
+        ],
+    )
+
+    strategy_definition = primap2.csg.StrategyDefinition(
+        strategies=[
+            ({'entity': ['SF6 (SARGWP100)']}, primap2.csg.SubstitutionStrategy()),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="No configured strategy was able to process"):
+        primap2.csg.compose(
+            input_data=input_data,
+            priority_definition=priority_definition,
+            strategy_definition=strategy_definition,
+        )
+
+
+
+
 def test_compose_pbar(opulent_ds):
     input_data = opulent_ds.drop_vars(["population", "SF6 (SARGWP100)"]).pr.loc[
         {"animal": ["cow"], "product": ["milk"], "category": ["0", "1"]}

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -505,7 +505,7 @@ def test_compose_variable_entity(opulent_ds):
 
     strategy_definition = primap2.csg.StrategyDefinition(
         strategies=[
-            ({'entity': ['SF6 (SARGWP100)']}, primap2.csg.SubstitutionStrategy()),
+            ({"entity": ["SF6 (SARGWP100)"]}, primap2.csg.SubstitutionStrategy()),
         ]
     )
 
@@ -515,8 +515,6 @@ def test_compose_variable_entity(opulent_ds):
             priority_definition=priority_definition,
             strategy_definition=strategy_definition,
         )
-
-
 
 
 def test_compose_pbar(opulent_ds):

--- a/primap2/tests/csg/test_compose.py
+++ b/primap2/tests/csg/test_compose.py
@@ -194,6 +194,41 @@ def test_compose_exclude_result(opulent_ds):
     assert result_sf6.isnull().all().all()
 
 
+def test_compose_invalid_strategy_definition(opulent_ds):
+    """We use an invalid strategy definition and verify it raises an error."""
+    input_data = opulent_ds.drop_vars(["population", "SF6 (SARGWP100)"]).pr.loc[
+        {
+            "animal": ["cow"],
+            "product": ["milk"],
+            "category": ["0", "1"],
+            "area": ["COL"],
+        }
+    ]
+    priority_definition = primap2.csg.PriorityDefinition(
+        priority_dimensions=["source"], priorities=[{"source": "RAND2020"}]
+    )
+    valid_strategy_definition = primap2.csg.StrategyDefinition(
+        [({}, primap2.csg.SubstitutionStrategy())],
+    )
+    primap2.csg.compose(
+        input_data=input_data,
+        priority_definition=priority_definition,
+        strategy_definition=valid_strategy_definition,
+    )
+    invalid_strategy_definition = primap2.csg.StrategyDefinition(
+        [
+            ({"notadim": "RAND2020"}, primap2.csg.SubstitutionStrategy()),
+            ({}, primap2.csg.SubstitutionStrategy()),
+        ],
+    )
+    with pytest.raises(ValueError, match="is not a valid dimension"):
+        primap2.csg.compose(
+            input_data=input_data,
+            priority_definition=priority_definition,
+            strategy_definition=invalid_strategy_definition,
+        )
+
+
 def test_compose_strategy_skipping(opulent_ds):
     """In this test, we use a strategy which raises an error and assert that it is
     skipped properly."""
@@ -370,6 +405,84 @@ def test_compose_skip_source(opulent_ds):
     assert tpd.steps[1].source == (
         "{'source': 'RAND2021', 'scenario (FAOSTAT)': 'highpop'}"
     )
+
+
+def test_compose_skip_variable(opulent_ds):
+    """We do skip processing SF6 (SARGWP100) altogether."""
+    input_data = opulent_ds.drop_vars(["population"]).pr.loc[
+        {
+            "animal": ["cow"],
+            "product": ["milk"],
+            "category": ["0", "1"],
+            "area": ["COL"],
+        }
+    ]
+
+    priority_definition = primap2.csg.PriorityDefinition(
+        priority_dimensions=["source"],
+        priorities=[
+            {"source": "RAND2020"},
+        ],
+        exclude_result=[{"variable": "SF6 (SARGWP100)"}],
+    )
+
+    strategy_definition = primap2.csg.StrategyDefinition(
+        strategies=[
+            ({}, primap2.csg.SubstitutionStrategy()),
+        ]
+    )
+
+    result = primap2.csg.compose(
+        input_data=input_data,
+        priority_definition=priority_definition,
+        strategy_definition=strategy_definition,
+    )
+    # The caller of `compose` is responsible for re-adding priority dimensions
+    # if necessary
+    result = result.expand_dims(dim={"source": ["composed"]})
+    result.pr.ensure_valid()
+
+    assert result["SF6 (SARGWP100)"].isnull().all()
+    assert not result["SF6"].isnull().all()
+
+
+def test_compose_skip_entity(opulent_ds):
+    """We do skip processing SF6, even with gwp_context."""
+    input_data = opulent_ds.drop_vars(["population"]).pr.loc[
+        {
+            "animal": ["cow"],
+            "product": ["milk"],
+            "category": ["0", "1"],
+            "area": ["COL"],
+        }
+    ]
+
+    priority_definition = primap2.csg.PriorityDefinition(
+        priority_dimensions=["source"],
+        priorities=[
+            {"source": "RAND2020"},
+        ],
+        exclude_result=[{"entity": "SF6"}],
+    )
+
+    strategy_definition = primap2.csg.StrategyDefinition(
+        strategies=[
+            ({}, primap2.csg.SubstitutionStrategy()),
+        ]
+    )
+
+    result = primap2.csg.compose(
+        input_data=input_data,
+        priority_definition=priority_definition,
+        strategy_definition=strategy_definition,
+    )
+    # The caller of `compose` is responsible for re-adding priority dimensions
+    # if necessary
+    result = result.expand_dims(dim={"source": ["composed"]})
+    result.pr.ensure_valid()
+
+    assert result["SF6 (SARGWP100)"].isnull().all()
+    assert result["SF6"].isnull().all()
 
 
 def test_compose_pbar(opulent_ds):

--- a/primap2/tests/csg/utils.py
+++ b/primap2/tests/csg/utils.py
@@ -11,6 +11,8 @@ def get_single_ts(
     data: np.ndarray | None = None,
     dims: Sequence[str] | None = None,
     coords: dict[str, str | Sequence[str]] | None = None,
+    entity: str = "CH4",
+    gwp_context: str | None = None,
 ) -> xr.DataArray:
     if time is None:
         time = pd.date_range("1850-01-01", "2022-01-01", freq="YS")
@@ -20,8 +22,16 @@ def get_single_ts(
         data = np.linspace(0.0, 1.0, len(time))
     if coords is None:
         coords = {}
+    if gwp_context is None:
+        name = entity
+        attrs = {"entity": entity}
+    else:
+        name = f"{entity} ({gwp_context})"
+        attrs = {"entity": entity, "gwp_context": gwp_context}
     return xr.DataArray(
         data,
         dims=["time", *dims],
         coords={"time": time, **coords},
+        name=name,
+        attrs=attrs,
     )


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [ ] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

* `entity` and `variable` are defined things in primap2, actually use the terms correctly in the code and interfaces.
* Allow filtering by `entity` and `variable` in strategy and priority definitions.
* Better error messages if undefined dimensions are used in strategy definitions.
