### PR TITLE
fix: interchange format works again with dimensionless units

### DIFF
--- a/changelog_unreleased/fix-if-dimensionless.rst
+++ b/changelog_unreleased/fix-if-dimensionless.rst
@@ -1,0 +1,2 @@
+* Fixed reading the interchange format with dimensionless data (where the unit is
+  an empty string).

--- a/primap2/pm2io/_interchange_format.py
+++ b/primap2/pm2io/_interchange_format.py
@@ -108,6 +108,10 @@ def metadata_for_variable(unit: str, variable: str) -> dict[str, str]:
 
     """
     attrs = {}
+
+    if not isinstance(unit, str):
+        unit = ""
+
     if unit != "no unit":
         attrs["units"] = unit
 
@@ -372,8 +376,8 @@ def from_interchange_format(
 
     # fill the entity/variable attributes
     for variable in data_xr:
-        csv_units = np.unique(units.loc[{entity_col: variable}])
-        if len(csv_units) > 1:
+        csv_units = np.unique(units.loc[{entity_col: variable}], equal_nan=True)
+        if len(csv_units) > 1 and any(isinstance(x, str) for x in csv_units):
             logger.error(
                 f"More than one unit for entity {variable!r}: {csv_units!r}. "
                 + "There is an error in the unit harmonization."


### PR DESCRIPTION
# Pull request

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description

Some library update (pandas or xarray, likely) broke parsing of dimensionless units from the interchange format due to NaN issues. This fixes it.
