### PR TITLE
workaround for xarray additional coordinate bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ lint: venv ## check style with pre-commit hooks
 	venv/bin/pre-commit run --all-files
 
 test: venv ## run tests quickly with the default Python
-	venv/bin/pytest  --xdoc -rx
+	# venv/bin/pytest  --xdoc -rx
+	venv/bin/pytest -rx
 
 test-all: ## run tests on every Python version with tox
 	tox -p

--- a/changelog_unreleased/xarray_coordinate_bug_workaround.md
+++ b/changelog_unreleased/xarray_coordinate_bug_workaround.md
@@ -1,0 +1,3 @@
+* Workaround for xarray's additional coordinate bug
+* Improved a few error messages
+* Disable xdoc as it throws errors

--- a/primap2/_aggregate.py
+++ b/primap2/_aggregate.py
@@ -346,13 +346,13 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
                     val for val in source_values if val in values_present
                 ]
                 missing_values = set(source_values) - set(source_values_present)
-                if missing_values:
-                    logger.info(
-                        f"Not all source values present for "
-                        f"{value_to_aggregate!r} in coordinate {full_coord_name!r}. "
-                        f"Missing: {missing_values}"
-                    )
                 if source_values_present:
+                    if missing_values:
+                        logger.info(
+                            f"Not all source values present for "
+                            f"{value_to_aggregate!r} in coordinate {full_coord_name!r}. "
+                            f"Missing: {missing_values}. (variable: {da_out.name})"
+                        )
                     filter.update({coordinate: source_values_present})
                     data_agg = da_out.pr.loc[filter].pr.sum(
                         dim=coordinate, skipna=skipna, min_count=min_count
@@ -389,12 +389,13 @@ class DataArrayAggregationAccessor(BaseDataArrayAccessor):
                     else:
                         logger.info(
                             f"All input data nan for '{value_to_aggregate}' in "
-                            f"coordinate {full_coord_name!r}."
+                            f"coordinate {full_coord_name!r}. (variable: {da_out.name})"
                         )
                 else:
                     logger.info(
                         f"No source value present for {value_to_aggregate!r} in "
                         f"coordinate {full_coord_name!r}. Missing: {missing_values}."
+                        f" (variable: {da_out.name})"
                     )
 
         da_out = da_out.pr.quantify()

--- a/primap2/_downscale.py
+++ b/primap2/_downscale.py
@@ -97,7 +97,7 @@ class DataArrayDownscalingAccessor(BaseDataArrayAccessor):
                 raise ValueError(
                     f"Sum of the basket_contents {basket_contents!r} deviates"
                     f" {devmax * 100} % from the basket"
-                    f" {basket!r}, which is more than the allowed 1 %. "
+                    f" {basket!r}, which is more than the allowed {tolerance*100}%. "
                     "To continue regardless, set check_consistency=False."
                 )
 
@@ -331,7 +331,8 @@ class DatasetDownscalingAccessor(BaseDatasetAccessor):
                 raise ValueError(
                     f"Sum of the basket_contents {basket_contents!r} deviates"
                     f" {devmax * 100} % from the basket"
-                    f" {basket!r}, which is more than the allowed 1 %. "
+                    f" {basket!r}, which is more than the allowed "
+                    f"{tolerance * 100}%. "
                     f" {deviation}"
                     "To continue regardless, set check_consistency=False."
                 )
@@ -356,4 +357,4 @@ class DatasetDownscalingAccessor(BaseDatasetAccessor):
                     downscaled[var].pint.to(ds_sel[var].pint.units)
                 )
 
-        return self._ds.fillna(downscaled_converted)
+        return self._ds.pr.fillna(downscaled_converted)

--- a/primap2/_fill_combine.py
+++ b/primap2/_fill_combine.py
@@ -1,0 +1,207 @@
+"""workaround for xarray coordinate bug
+
+Additional coordinates are lost during operations that require aligning if the
+coordinates differ for the structures to be aligned.
+
+see https://github.com/pydata/xarray/issues/9124
+
+"""
+
+import xarray as xr
+from loguru import logger
+
+from ._accessor_base import BaseDataArrayAccessor, BaseDatasetAccessor
+
+
+class DataArrayFillAccessor(BaseDataArrayAccessor):
+    def fillna(self: xr.DataArray, da_fill: xr.DataArray) -> xr.DataArray:
+        """
+        Wrapper for `fillna` which ensures that additional coordinates present in
+        the calling DataArray are also present in the result. The default xarray
+        `fillna` implementation silently drops additional (non-indexed) coordinates
+        if they need alignment (do not cover the same values in both DataArrays)
+
+
+        Parameters
+        ----------
+        da_fill
+            DataArray used to fill nan values in the calling DataArray
+
+        Returns
+        -------
+            calling DatArray where nan values are filled from da_fill where possible
+
+        """
+        da_start = self._da
+
+        coords_start = da_start.coords
+        coords_fill = da_fill.coords
+        filled = da_start.fillna(da_fill)
+        # check if we lost a coordinate
+        missing_coords = set(coords_start).difference(set(filled.coords))
+        for coord in missing_coords:
+            try:
+                # merge and align the coordinate
+                logger.info(f"adding coord: {coord}")
+                coords_merged = coords_start[coord].fillna(coords_fill[coord])
+                aligned = xr.align(filled, coords_merged, join="outer")
+                # set the coordinate
+                filled = aligned[0].assign_coords(
+                    {coord: (coords_start[coord].dims, aligned[1].data)}
+                )
+            except Exception as ex:
+                message = f"Could not re-add lost coordinate {coord}: {ex}"
+                logger.error(message)
+                raise ValueError(message) from ex
+
+        return filled
+
+    def combine_first(self: xr.DataArray, da_combine: xr.DataArray) -> xr.DataArray:
+        """
+        Wrapper for `combine_first` which ensures that additional coordinates
+        present in the calling dataset are also present in the result. The default
+        xarray `fillna` implementation silently drops additional (non-indexed)
+        coordinates if they need alignment (do not cover the same values in both
+        DataArrays)
+
+
+        Parameters
+        ----------
+        da_combine
+            DataArray used to combine with the calling DataArray
+
+        Returns
+        -------
+            calling DataArray combined with da_combine
+
+        """
+        da_start = self._da
+
+        coords_start = da_start.coords
+        coords_fill = da_combine.coords
+        filled = da_start.combine_first(da_combine)
+        # check if we lost a coordinate
+        missing_coords = set(coords_start).difference(set(filled.coords))
+        for coord in missing_coords:
+            try:
+                # merge and align the coordinate
+                logger.info(f"adding coord: {coord}")
+                coords_merged = coords_start[coord].combine_first(coords_fill[coord])
+                aligned = xr.align(filled, coords_merged, join="outer")
+                # set the coordinate
+                filled = aligned[0].assign_coords(
+                    {coord: (coords_start[coord].dims, aligned[1].data)}
+                )
+            except Exception as ex:
+                message = f"Could not re-add lost coordinate {coord}: {ex}"
+                logger.error(message)
+                raise ValueError(message) from ex
+
+        return filled
+
+
+class DatasetFillAccessor(BaseDatasetAccessor):
+    # fillna, combine_first
+    def fillna(
+        self: xr.Dataset,
+        ds_fill: xr.Dataset | xr.DataArray,
+    ) -> xr.Dataset:
+        """
+        Wrapper for `fillna` which ensures that additional coordinates present in
+        the calling Dataset are also present in the result. The default xarray
+        `fillna` implementation silently drops additional (non-indexed) coordinates
+        if they need alignment (do not cover the same values in both Datasets)
+
+
+        Parameters
+        ----------
+        ds_fill
+            Dataset or DataArray used to fill nan values in the calling dataset
+
+        Returns
+        -------
+            calling Dataset where nan values are filled from ds_fill where possible
+
+        """
+
+        if self._ds.pr.has_processing_info():
+            raise NotImplementedError(
+                "Dataset contains processing information, this is not supported yet. "
+                "Use ds.pr.remove_processing_info()."
+            )
+
+        ds_start = self._ds
+
+        coords_start = ds_start.coords
+        coords_fill = ds_fill.coords
+        filled = ds_start.fillna(ds_fill)
+        # check if we lost a coordinate
+        missing_coords = set(coords_start).difference(set(filled.coords))
+        for coord in missing_coords:
+            try:
+                # merge and align the coordinate
+                logger.info(f"adding coord: {coord}")
+                coords_merged = coords_start[coord].fillna(coords_fill[coord])
+                aligned = xr.align(filled, coords_merged, join="outer")
+                # set the coordinate
+                filled = aligned[0].assign_coords(
+                    {coord: (coords_start[coord].dims, aligned[1].data)}
+                )
+            except Exception as ex:
+                message = f"Could not re-add lost coordinate {coord}: {ex}"
+                logger.error(message)
+                raise ValueError(message) from ex
+
+        return filled
+
+    def combine_first(
+        self: xr.Dataset,
+        ds_combine: xr.Dataset | xr.DataArray,
+    ) -> xr.Dataset:
+        """
+        Wrapper for `fillna` which ensures that additional coordinates present in
+        the calling Dataset are also present in the result. The default xarray
+        `fillna` implementation silently drops additional (non-indexed) coordinates
+        if they need alignment (do not cover the same values in both Datasets)
+
+
+        Parameters
+        ----------
+        ds_combine
+            Dataset or DataArray to combine with the calling Dataset
+
+        Returns
+        -------
+            calling Dataset calling DataArray combined with da_combine
+
+        """
+
+        if self._ds.pr.has_processing_info():
+            raise NotImplementedError(
+                "Dataset contains processing information, this is not supported yet. "
+                "Use ds.pr.remove_processing_info()."
+            )
+
+        ds_start = self._ds
+
+        coords_start = ds_start.coords
+        coords_fill = ds_combine.coords
+        filled = ds_start.combine_first(ds_combine)
+        # check if we lost a coordinate
+        missing_coords = set(coords_start).difference(set(filled.coords))
+        for coord in missing_coords:
+            try:
+                # merge and align the coordinate
+                logger.info(f"adding coord: {coord}")
+                coords_merged = coords_start[coord].combine_first(coords_fill[coord])
+                aligned = xr.align(filled, coords_merged, join="outer")
+                # set the coordinate
+                filled = aligned[0].assign_coords(
+                    {coord: (coords_start[coord].dims, aligned[1].data)}
+                )
+            except Exception as ex:
+                message = f"Could not re-add lost coordinate {coord}: {ex}"
+                logger.error(message)
+                raise ValueError(message) from ex
+
+        return filled

--- a/primap2/_fill_combine.py
+++ b/primap2/_fill_combine.py
@@ -101,7 +101,6 @@ class DataArrayFillAccessor(BaseDataArrayAccessor):
 
 
 class DatasetFillAccessor(BaseDatasetAccessor):
-    # fillna, combine_first
     def fillna(
         self: xr.Dataset,
         ds_fill: xr.Dataset | xr.DataArray,

--- a/primap2/_merge.py
+++ b/primap2/_merge.py
@@ -1,6 +1,7 @@
 """Merge arrays and datasets with optional tolerances."""
 
 import contextlib
+from datetime import date
 
 import numpy as np
 import xarray as xr
@@ -77,7 +78,7 @@ def merge_with_tolerance_core(
 
     # all differences are within the tolerance or ignored, take the first
     # value everywhere
-    return da_start.combine_first(da_merge)
+    return da_start.pr.combine_first(da_merge)
 
 
 def generate_log_message(da_error: xr.DataArray, tolerance: float) -> str:
@@ -88,6 +89,13 @@ def generate_log_message(da_error: xr.DataArray, tolerance: float) -> str:
     * convert the rest into a pandas dataframe for nice printing
     """
     scalar_dims = [dim for dim in da_error.dims if len(da_error[dim]) == 1]
+    scalar_dims_format = []
+    for dim in scalar_dims:
+        if dim == "time":
+            single_date = date.fromtimestamp(da_error[dim].item() / 1000000000)
+            scalar_dims_format.append(f"{dim}={single_date.strftime('%Y')}")
+        else:
+            scalar_dims_format.append(f"{dim}={da_error[dim].item()}")
     scalar_dims_str = ", ".join(f"{dim}={da_error[dim].item()}" for dim in scalar_dims)
     da_error_dequ = da_error.squeeze(drop=True).pint.dequantify()
     if np.ndim(da_error_dequ.data) == 0:
@@ -98,7 +106,7 @@ def generate_log_message(da_error: xr.DataArray, tolerance: float) -> str:
     return (
         f"pr.merge error: found discrepancies larger than tolerance "
         f"({tolerance * 100:.2f}%) for {scalar_dims_str}:\n"
-        f"shown are relative discrepancies.\n" + errors_str
+        f"shown are relative discrepancies. ({da_error.name})\n" + errors_str
     )
 
 

--- a/primap2/accessors.py
+++ b/primap2/accessors.py
@@ -5,6 +5,7 @@ import xarray as xr
 from ._aggregate import DataArrayAggregationAccessor, DatasetAggregationAccessor
 from ._data_format import DatasetDataFormatAccessor
 from ._downscale import DataArrayDownscalingAccessor, DatasetDownscalingAccessor
+from ._fill_combine import DataArrayFillAccessor, DatasetFillAccessor
 from ._merge import DataArrayMergeAccessor, DatasetMergeAccessor
 from ._metadata import DatasetMetadataAccessor
 from ._overview import DataArrayOverviewAccessor, DatasetOverviewAccessor
@@ -27,6 +28,7 @@ class PRIMAP2DatasetAccessor(
     DatasetOverviewAccessor,
     DatasetSettersAccessor,
     DatasetUnitAccessor,
+    DatasetFillAccessor,
 ):
     """Collection of methods useful for climate policy analysis."""
 
@@ -40,5 +42,6 @@ class PRIMAP2DataArrayAccessor(
     DataArrayOverviewAccessor,
     DataArraySettersAccessor,
     DataArrayUnitAccessor,
+    DataArrayFillAccessor,
 ):
     """Collection of methods useful for climate policy analysis."""

--- a/primap2/tests/test_fill_combine.py
+++ b/primap2/tests/test_fill_combine.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+"""Tests for _fill_combine.py
+
+We only test the features regarding the buggy treatment of additional (non-indexed)
+coordinates here. All core functionality is assumed to be sufficiently tested in xarray
+"""
+
+import numpy as np
+
+
+def test_fillna_ds_coord_present(minimal_ds):
+    # add additional coordinate
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    full_ds = minimal_ds.assign_coords(country_name=("area (ISO3)", country_names))
+
+    sel = {"area (ISO3)": ["COL", "MEX"]}
+    sel_ds = full_ds.pr.loc[sel]
+    nan_ds = full_ds.copy()
+    nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] = (
+        nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] * np.nan
+    )
+
+    result_ds = nan_ds.pr.fillna(sel_ds)
+
+    # assert_ds_aligned_equal(result_ds, full_ds)
+    # above fails because data type of country_names differs
+
+    # check that the additional coord is present in result
+    assert "country_name" in list(result_ds.coords)
+    # check that the mapping of country names to country codes is intact
+    # (meaning that the additional coordinate is aligned correctly)
+    for country in full_ds.coords["area (ISO3)"].values:
+        assert (
+            result_ds.coords["country_name"].loc[{"area (ISO3)": country}]
+            == full_ds.coords["country_name"].loc[{"area (ISO3)": country}]
+        )
+
+
+def test_fillna_da_coord_present(minimal_ds):
+    # add additional coordinate
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    full_ds = minimal_ds.assign_coords(country_name=("area (ISO3)", country_names))
+
+    sel = {"area (ISO3)": ["COL", "MEX"]}
+    sel_ds = full_ds.pr.loc[sel]
+    nan_ds = full_ds.copy()
+    nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] = (
+        nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] * np.nan
+    )
+
+    result_da = nan_ds["CO2"].pr.fillna(sel_ds["CO2"])
+
+    # check that the additional coord is present in result
+    assert "country_name" in list(result_da.coords)
+    # check that the mapping of country names to country codes is intact
+    # (meaning that the additional coordinate is aligned correctly)
+    for country in full_ds.coords["area (ISO3)"].values:
+        assert (
+            result_da.coords["country_name"].loc[{"area (ISO3)": country}]
+            == full_ds.coords["country_name"].loc[{"area (ISO3)": country}]
+        )
+
+
+def test_combine_first_ds_coord_present(minimal_ds):
+    # add additional coordinate
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    full_ds = minimal_ds.assign_coords(country_name=("area (ISO3)", country_names))
+
+    sel = {"area (ISO3)": ["COL", "MEX"]}
+    sel_ds = full_ds.pr.loc[sel]
+    nan_ds = full_ds.pr.loc[{"area (ISO3)": ["ARG", "COL"]}]
+    nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] = (
+        nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] * np.nan
+    )
+
+    result_ds = nan_ds.pr.combine_first(sel_ds)
+    compare_ds = full_ds.pr.loc[{"area (ISO3)": ["ARG", "COL", "MEX"]}]
+
+    # check that the additional coord is present in result
+    assert "country_name" in list(result_ds.coords)
+    # check that the mapping of country names to country codes is intact
+    # (meaning that the additional coordinate is aligned correctly)
+    for country in compare_ds.coords["area (ISO3)"].values:
+        assert (
+            result_ds.coords["country_name"].loc[{"area (ISO3)": country}]
+            == compare_ds.coords["country_name"].loc[{"area (ISO3)": country}]
+        )
+
+
+def test_combine_first_da_coord_present(minimal_ds):
+    # add additional coordinate
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    full_ds = minimal_ds.assign_coords(country_name=("area (ISO3)", country_names))
+
+    sel = {"area (ISO3)": ["COL", "MEX"]}
+    sel_ds = full_ds.pr.loc[sel]
+    nan_ds = full_ds.pr.loc[{"area (ISO3)": ["ARG", "COL"]}]
+    nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] = (
+        nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] * np.nan
+    )
+
+    result_da = nan_ds["CO2"].pr.combine_first(sel_ds["CO2"])
+    compare_da = full_ds["CO2"].pr.loc[{"area (ISO3)": ["ARG", "COL", "MEX"]}]
+
+    # check that the additional coord is present in result
+    assert "country_name" in list(result_da.coords)
+    # check that the mapping of country names to country codes is intact
+    # (meaning that the additional coordinate is aligned correctly)
+    for country in compare_da.coords["area (ISO3)"].values:
+        assert (
+            result_da.coords["country_name"].loc[{"area (ISO3)": country}]
+            == compare_da.coords["country_name"].loc[{"area (ISO3)": country}]
+        )
+
+
+# tests to check if xarray bug persists
+def test_fillna_ds_xr_fail(minimal_ds):
+    # add additional coordinate
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    full_ds = minimal_ds.assign_coords(country_name=("area (ISO3)", country_names))
+
+    sel = {"area (ISO3)": ["COL", "MEX"]}
+    sel_ds = full_ds.pr.loc[sel]
+    nan_ds = full_ds.copy()
+    nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] = (
+        nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] * np.nan
+    )
+
+    result_ds = nan_ds.fillna(sel_ds)
+
+    assert "country_name" not in list(result_ds.coords)
+
+
+def test_combine_first_ds_xr_fail(minimal_ds):
+    # add additional coordinate
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    full_ds = minimal_ds.assign_coords(country_name=("area (ISO3)", country_names))
+
+    sel = {"area (ISO3)": ["COL", "MEX"]}
+    sel_ds = full_ds.pr.loc[sel]
+    nan_ds = full_ds.pr.loc[{"area (ISO3)": ["ARG", "COL"]}]
+    nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] = (
+        nan_ds["CO2"].pr.loc[{"area (ISO3)": "COL"}] * np.nan
+    )
+
+    result_ds = nan_ds.combine_first(sel_ds)
+
+    assert "country_name" not in list(result_ds.coords)

--- a/primap2/tests/test_merge.py
+++ b/primap2/tests/test_merge.py
@@ -109,3 +109,75 @@ def test_dims_not_matching_da(opulent_ds):
         ValueError, match="pr.merge error: dims of objects to merge must agree"
     ):
         da_start.pr.merge(da_merge)
+
+
+# tests to check if additional coords stay in place during merge. Different setups as pr.merge
+# uses different methods depending on the setup. as xr.merge is not affected by the coordinate
+# bug these tests could also be removed. But if kept they detect if the bug appears for xr.merge
+def test_merge_ds_add_coord(opulent_ds):
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    ds_full = opulent_ds.assign_coords(country_name=("area (ISO3)", country_names))
+    sel = {"time": slice("2000", "2005"), "scenario": "highpop", "source": "RAND2020"}
+    ds = ds_full.pr.loc[sel]
+    ds_start = ds.pr.loc[{"area": ["ARG", "COL"]}]
+    ds_merge = ds.pr.loc[{"area": ["ARG", "MEX"]}]
+
+    ds_result = ds_start.pr.merge(ds_merge, tolerance=0.01)
+    ds_compare = ds.pr.loc[{"area (ISO3)": ["ARG", "COL", "MEX"]}]
+
+    # check that the additional coord is present in result
+    assert "country_name" in list(ds_result.coords)
+    # check that the mapping of country names to country codes is intact
+    # (meaning that the additional coordinate is aligned correctly)
+    for country in ds_compare.coords["area (ISO3)"].values:
+        assert (
+            ds_result.coords["country_name"].loc[{"area (ISO3)": country}]
+            == ds_compare.coords["country_name"].loc[{"area (ISO3)": country}]
+        )
+
+
+def test_merge_ds_add_coord_tolerance(opulent_ds):
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    ds_full = opulent_ds.assign_coords(country_name=("area (ISO3)", country_names))
+    sel = {"time": slice("2000", "2005"), "scenario": "highpop", "source": "RAND2020"}
+    ds = ds_full.pr.loc[sel]
+    ds_start = ds.pr.loc[{"area": ["ARG", "COL"]}]
+    ds_merge = ds.pr.loc[{"area": ["ARG", "MEX"]}]
+
+    data_to_modify = ds["CO2"].pr.loc[{"area": ["ARG"]}].pr.sum("area")
+    data_to_modify.data *= 1.009
+
+    da_merge = ds["CO2"].pr.set("area", "ARG", data_to_modify, existing="overwrite")
+    ds_merge["CO2"] = da_merge
+    ds_result = ds_start.pr.merge(ds_merge, tolerance=0.01)
+    ds_compare = ds.pr.loc[{"area (ISO3)": ["ARG", "COL", "MEX"]}]
+
+    # check that the additional coord is present in result
+    assert "country_name" in list(ds_result.coords)
+    # check that the mapping of country names to country codes is intact
+    # (meaning that the additional coordinate is aligned correctly)
+    for country in ds_compare.coords["area (ISO3)"].values:
+        assert (
+            ds_result.coords["country_name"].loc[{"area (ISO3)": country}]
+            == ds_compare.coords["country_name"].loc[{"area (ISO3)": country}]
+        )
+
+
+def test_merge_ds_add_coord_disjoint_vars(opulent_ds):
+    country_names = ["Colombia", "Argentina", "Mexico", "Bolivia"]
+    ds_full = opulent_ds.assign_coords(country_name=("area (ISO3)", country_names))
+
+    ds_start: xr.Dataset = ds_full[["CO2"]]
+    ds_merge: xr.Dataset = ds_full[["CH4"]]
+    ds_result = ds_start.pr.merge(ds_merge)
+    ds_compare = ds_full[["CO2", "CH4"]]
+
+    # check that the additional coord is present in result
+    assert "country_name" in list(ds_merge.coords)
+    # check that the mapping of country names to country codes is intact
+    # (meaning that the additional coordinate is aligned correctly)
+    for country in ds_compare.coords["area (ISO3)"].values:
+        assert (
+            ds_result.coords["country_name"].loc[{"area (ISO3)": country}]
+            == ds_compare.coords["country_name"].loc[{"area (ISO3)": country}]
+        )


### PR DESCRIPTION
This pr adds a workaround for the issue with additional (non-indexed) coordinates in some xarray functions (https://github.com/pydata/xarray/issues/9124). 

There are also some small improvements of error messages included. 

# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable) <- not applicable here
- [x] Description in a ``.rst`` file in the directory ``changelog_unreleased`` added - remember to include a ``*`` to make it a bullet point

## Description
The workaround is to add custom `pr.fillna` and `pr.combine_first` methods which wrap around `fillna` and `combine_first` and take care of the additional coordinate. 

The improvements to error messages are to give more relevant information on the data that caused the error.

